### PR TITLE
Upgraded to latest Equinox; removed Chex dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "haliax"
-version = "1.0.1"
+version = "1.0.2"
 authors = [
   { name="David Hall", email="dlwh@cs.stanford.edu" },
 ]
@@ -22,9 +22,9 @@ classifiers = [
 dependencies = [
     # we'll require that you install jax yourself, since the extras vary by system.
     # jax = {version = ">=0.4.10,<0.5.0"}
-    "equinox~=0.9.0",
+    "equinox>=0.10.6",
+    "jaxtyping>=0.2.20",
     "safetensors[numpy]",
-    "chex",
 ]
 
 [project.optional-dependencies]

--- a/src/haliax/hof.py
+++ b/src/haliax/hof.py
@@ -6,7 +6,6 @@ from typing import Any, Callable, Tuple, TypeVar, Union
 import equinox as eqx
 import jax
 import jax.lax as lax
-from equinox.custom_types import BoolAxisSpec
 from jaxtyping import PyTree
 
 from .core import NamedArray, selects_axis
@@ -16,6 +15,7 @@ from .types import Axis, AxisSelector
 from .util import index_where, is_jax_or_hax_array_like, is_named_array
 
 
+BoolAxisSpec = Union[bool, Callable[[Any], bool]]
 Carry = TypeVar("Carry")
 X = TypeVar("X")
 Y = TypeVar("Y")

--- a/src/haliax/jax_utils.py
+++ b/src/haliax/jax_utils.py
@@ -4,11 +4,13 @@ from typing import Any, Callable, List, Optional, Sequence, Union
 import equinox as eqx
 import jax
 import numpy as np
-from chex import PRNGKey
-from equinox.module import Static
 from jax import numpy as jnp
 from jax import random as jrandom
-from jaxtyping import PyTree
+from jaxtyping import PyTree, PRNGKeyArray
+
+
+class Static(eqx.Module):
+    value: Any = eqx.field(static=True)
 
 
 def shaped_rng_split(key, split_shape: Union[int, Sequence[int]] = 2) -> jrandom.KeyArray:
@@ -26,7 +28,7 @@ def shaped_rng_split(key, split_shape: Union[int, Sequence[int]] = 2) -> jrandom
     return jnp.reshape(unshaped, split_shape)
 
 
-def maybe_rng_split(key: Optional[PRNGKey], num: int = 2):
+def maybe_rng_split(key: Optional[PRNGKeyArray], num: int = 2):
     """Splits a random key into multiple random keys. If the key is None, then it replicates the None. Also handles
     num == 1 case"""
     if key is None:

--- a/src/haliax/nn/attention.py
+++ b/src/haliax/nn/attention.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax.random import PRNGKey
+from jaxtyping import PRNGKeyArray
 
 import haliax
 import haliax.random as hrandom
@@ -157,14 +157,14 @@ def prefix_lm_mask(QSeqLen: Axis, KSeqLen: Axis, prefix_len: int) -> NamedArray:
     return prefix | causal
 
 
-def dropout_mask(axes: AxisSpec, dropout_rate: float, *, key: PRNGKey) -> NamedArray:
+def dropout_mask(axes: AxisSpec, dropout_rate: float, *, key: PRNGKeyArray) -> NamedArray:
     """
     Really just an alias for haliax.random.bernoulli. You can pass in e.g. Head, QPos and KPos
     """
     return hrandom.bernoulli(key, shape=axes, p=1 - dropout_rate)
 
 
-def forgetful_causal_mask(KPos: Axis, mask_prob: float, sample_prob: bool = True, *, key: PRNGKey) -> NamedArray:
+def forgetful_causal_mask(KPos: Axis, mask_prob: float, sample_prob: bool = True, *, key: PRNGKeyArray) -> NamedArray:
     """
     Forgetful Context Masking a la https://arxiv.org/abs/2210.13432. Randomly drops out positions from the key sequence.
     Reportedly better than normal attention dropout. Almost certainly faster.

--- a/src/haliax/nn/dropout.py
+++ b/src/haliax/nn/dropout.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import equinox as eqx
 import jax
+from jaxtyping import PRNGKeyArray
 
 import haliax
 from haliax.core import NamedArray
@@ -76,7 +77,7 @@ class Dropout(eqx.Module):
         x: NamedArray,
         *,
         inference: bool,
-        key: Optional["jax.random.PRNGKey"] = None,
+        key: Optional[PRNGKeyArray] = None,
     ) -> NamedArray:
         """**Arguments:**
 

--- a/src/haliax/nn/scan.py
+++ b/src/haliax/nn/scan.py
@@ -90,5 +90,5 @@ class Stacked(eqx.Module, Generic[M]):
         return block(carry, *extra_args, **extra_kwargs)
 
     # TODO: this is for logic that's in levanter. We should move that logic to haliax I guess?
-    def _state_dict_key_map(self) -> Optional[Dict[str, Optional[str]]]:
+    def _state_dict_key_map(self) -> Dict[str, Optional[str]]:
         return {"stacked": None}

--- a/src/haliax/partitioning.py
+++ b/src/haliax/partitioning.py
@@ -7,7 +7,8 @@ from typing import Mapping, Optional, Sequence, TypeVar, Union
 
 import equinox as eqx
 import jax
-from equinox.compile_utils import compile_cache, get_fun_names, hashable_combine, hashable_partition
+# TODO: avoid depending on private Equinox internals.
+from equinox._compile_utils import compile_cache, hashable_combine, hashable_partition
 from jax._src.sharding_impls import AUTO
 from jax.experimental.pjit import pjit
 from jax.lax import with_sharding_constraint
@@ -292,7 +293,7 @@ def named_jit(
             cmanager = contextlib.nullcontext()
 
         with cmanager:
-            cached_pjitted_fun = _named_pjit_cache(get_fun_names(fn), **my_pjit_args)
+            cached_pjitted_fun = _named_pjit_cache(fn, **my_pjit_args)
             return cached_pjitted_fun(dynamic_donated, dynamic_reserved, static)
 
     return f

--- a/src/haliax/tree_util.py
+++ b/src/haliax/tree_util.py
@@ -1,12 +1,11 @@
 import jax
-from jax.random import PRNGKey
-from jaxtyping import PyTree
+from jaxtyping import PyTree, PRNGKeyArray
 
 from .core import Axis, NamedArray
 from .util import is_named_array
 
 
-def resize_axis(tree: PyTree[NamedArray], axis: Axis, key: PRNGKey):
+def resize_axis(tree: PyTree[NamedArray], axis: Axis, key: PRNGKeyArray):
     """Resizes the NamedArrays of a PyTree along a given axis. If the array needs to grow, then the new elements are
     sampled from a truncated normal distribution with the same mean and standard deviation as the existing elements.
     If the array needs to shrink, then it's truncated."""

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -2,7 +2,7 @@ from typing import Callable
 
 import jax
 import jax.numpy as jnp
-from chex import PRNGKey
+from jaxtyping import PRNGKeyArray
 
 import haliax as hax
 from haliax.random import generate_sharded
@@ -96,7 +96,7 @@ def test_randint():
 
 
 def check_gen_is_equal(
-    jax_fn: Callable[[PRNGKey, tuple], jnp.ndarray], hax_fn: Callable[[PRNGKey, hax.AxisSpec], hax.NamedArray]
+    jax_fn: Callable[[PRNGKeyArray, tuple], jnp.ndarray], hax_fn: Callable[[PRNGKeyArray, hax.AxisSpec], hax.NamedArray]
 ):
     key = jax.random.PRNGKey(0)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,9 +3,9 @@ from typing import Callable, List, Optional, TypeVar
 import equinox as eqx
 import jax
 import pytest
-from chex import assert_trees_all_close
 from equinox import nn as nn
 from equinox import static_field
+from jaxtyping import PRNGKeyArray
 
 
 T = TypeVar("T")
@@ -35,7 +35,7 @@ class MLP(eqx.Module):
         activation: Callable = jax.nn.relu,
         final_activation: Callable = lambda x: x,
         *,
-        key: "jax.random.PRNGKey",
+        key: PRNGKeyArray,
         **kwargs,
     ):
         """**Arguments**:
@@ -70,7 +70,7 @@ class MLP(eqx.Module):
         self.activation = activation  # type: ignore
         self.final_activation = final_activation  # type: ignore
 
-    def __call__(self, x, *, key: Optional["jax.random.PRNGKey"] = None):
+    def __call__(self, x, *, key: Optional[PRNGKeyArray] = None):
         """**Arguments:**
 
         - `x`: A JAX array with shape `(in_size,)`.
@@ -89,23 +89,9 @@ class MLP(eqx.Module):
         return x
 
 
-def assert_trees_not_close(a, b):
-    try:
-        assert_trees_all_close(jax.tree_util.tree_leaves(arrays_only(a)), jax.tree_util.tree_leaves(arrays_only(b)))
-    except AssertionError:
-        pass
-    else:
-        raise AssertionError("Trees are equal")
-
-
-def arrays_only(x):
-    return eqx.filter(x, eqx.is_inexact_array_like)
-
-
 def has_torch():
     try:
         import torch  # noqa F401
-
         return True
     except ImportError:
         return False


### PR DESCRIPTION
The primary purpose of this PR is to upgrade Haliax to be compatible with the latest Equinox (v0.10.6).

En passant, I also made use of the recently-added `jaxtyping.PRNGKeyArray`, which also made it possible to drop the dependency on Chex.

I've bumped the version number so that Levanter can use this.

I didn't run the pre-commit hooks as they tried to reformat a lot of things that I didn't touch.