### PR TITLE
Batched Take 

### DIFF
--- a/src/haliax/__init__.py
+++ b/src/haliax/__init__.py
@@ -3,8 +3,9 @@ from typing import Optional, Sequence
 import jax
 import jax.numpy as jnp
 
+import haliax.nn as nn
 import haliax.random as random
-from haliax import tree_util as tree_util
+import haliax.tree_util as tree_util
 
 from .axis import Axis, AxisSelection, AxisSelector, AxisSpec, concat_axes, eliminate_axes, selects_axis
 from .core import (
@@ -251,6 +252,9 @@ concat_axis_specs = concat_axes
 
 
 __all__ = [
+    "random",
+    "tree_util",
+    "nn",
     "Axis",
     "AxisSpec",
     "AxisSelection",

--- a/src/haliax/core.py
+++ b/src/haliax/core.py
@@ -626,7 +626,7 @@ def take(array: NamedArray, axis: AxisSelector, index: Union[int, NamedArray]) -
                 index = index.rename({axis.name: "__DUMMY_" + axis.name})
             array = haliax.broadcast_to(array, index.axes, ensure_order=False, enforce_no_extra_axes=False)
             new_axes = eliminate_axes(array.axes, axis)
-            index = haliax.broadcast_to(index, new_axes, ensure_order=True, enforce_no_extra_axes=False)
+            index = haliax.broadcast_to(index, new_axes, ensure_order=True, enforce_no_extra_axes=True)
 
             axis_index = array._lookup_indices(axis)  # if it moved
             index_array = jnp.expand_dims(index.array, axis=axis_index)

--- a/src/haliax/nn/__init__.py
+++ b/src/haliax/nn/__init__.py
@@ -9,7 +9,7 @@ import haliax
 import haliax as hax
 import haliax.nn.attention as attention
 
-from .. import Axis, AxisSelector, AxisSpec
+from ..axis import Axis, AxisSelector, AxisSpec
 from ..core import NamedArray
 from ..util import UNSPECIFIED, Unspecified
 from ..wrap import ReductionFunction, unwrap_namedarrays, wrap_axiswise_call, wrap_elemwise_unary, wrap_reduction_call

--- a/src/haliax/nn/attention.py
+++ b/src/haliax/nn/attention.py
@@ -8,7 +8,7 @@ from jaxtyping import PRNGKeyArray
 
 import haliax
 import haliax.random as hrandom
-from haliax import Axis, AxisSelection, AxisSpec
+from haliax.axis import Axis, AxisSelection, AxisSpec
 from haliax.core import NamedArray
 from haliax.types import PrecisionLike
 

--- a/src/haliax/nn/scan.py
+++ b/src/haliax/nn/scan.py
@@ -4,8 +4,9 @@ from typing import Dict, Generic, Optional, Protocol, Type, TypeVar
 import equinox as eqx
 
 import haliax
-import haliax as hax
 from haliax.jax_utils import filter_checkpoint
+
+from ..axis import Axis
 
 
 M = TypeVar("M", bound=eqx.Module, covariant=True)
@@ -57,12 +58,12 @@ class Stacked(eqx.Module, Generic[M]):
     # TODO: we can probably make this module support pipeline parallelism, but that's a whole project in itself
 
     stacked: M
-    Block: hax.Axis = eqx.static_field()
+    Block: Axis = eqx.static_field()
     # TODO: support fancier gradient checkpointing
     gradient_checkpointing: bool = eqx.static_field()
 
     @staticmethod
-    def init(Block: hax.Axis, module: Type[M], *, gradient_checkpointing: bool = False) -> ModuleInit["Stacked[M]"]:
+    def init(Block: Axis, module: Type[M], *, gradient_checkpointing: bool = False) -> ModuleInit["Stacked[M]"]:
         @functools.wraps(module)
         def fn(*args, **kwargs):
             stacked = haliax.vmap(module.init, Block)(*args, **kwargs)

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -251,12 +251,20 @@ def test_take_overlapping_2():
 
     loss = cross_entropy(logits, labels)
     assert loss.axes == (Batch, Block)
-    assert loss.array == jnp.take_along_axis(logits.array, labels.array[..., None], axis=-1)[..., 0]
+    assert jnp.alltrue(loss.array == jnp.take_along_axis(logits.array, labels.array[..., None], axis=-1)[..., 0])
 
     logits = hax.random.uniform(PRNGKey(0), (Batch, Embed, Block))
 
     loss = cross_entropy(logits, labels)
     assert loss.axes == (Batch, Block)
+    assert jnp.alltrue(loss.array == jnp.take_along_axis(logits.array, labels.array[..., None, :], axis=-2)[..., 0, :])
+
+    index = hax.random.randint(PRNGKey(0), (Block, Batch), 0, Embed.size)
+    loss = cross_entropy(logits, index)
+    assert loss.axes == (Batch, Block)
+    assert jnp.alltrue(
+        loss.array == jnp.take_along_axis(logits.array, index.array.transpose()[..., None, :], axis=-2)[..., 0, :]
+    )
 
 
 def test_cumsum_etc():

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -222,6 +222,43 @@ def test_take():
     assert named2.axes == (Height, Width, Index, Index2)
 
 
+def test_take_overlapping_names():
+    Height = Axis("Height", 20)
+    Width = Axis("Width", 30)
+    Depth = Axis("Depth", 40)
+    named1 = hax.random.uniform(PRNGKey(0), (Height, Width, Depth))
+
+    Height2 = Axis("Height", 10)
+    indices_to_take = hax.arange(Height2, dtype=jnp.int32)
+    named2 = hax.take(named1, Height, indices_to_take)
+
+    assert named2.axes == (Height2, Width, Depth)
+    assert named2.array.shape == (10, 30, 40)
+
+    assert jnp.all(jnp.equal(named2.array, named1.array[:10]))
+
+
+def test_take_overlapping_2():
+    # https://github.com/stanford-crfm/haliax/issues/13
+    def cross_entropy(logits: hax.NamedArray, labels: hax.NamedArray) -> hax.NamedArray:
+        return hax.take(logits, Embed, labels)  # extract log probability of the correct token
+
+    Embed = Axis("Embed", 10)
+    Block = Axis("Block", 20)
+    Batch = Axis("Batch", 30)
+    logits = hax.random.uniform(PRNGKey(0), (Batch, Block, Embed))
+    labels = hax.random.randint(PRNGKey(0), (Batch, Block), 0, Embed.size)
+
+    loss = cross_entropy(logits, labels)
+    assert loss.axes == (Batch, Block)
+    assert loss.array == jnp.take_along_axis(logits.array, labels.array[..., None], axis=-1)[..., 0]
+
+    logits = hax.random.uniform(PRNGKey(0), (Batch, Embed, Block))
+
+    loss = cross_entropy(logits, labels)
+    assert loss.axes == (Batch, Block)
+
+
 def test_cumsum_etc():
     Height = Axis("Height", 2)
     Width = Axis("Width", 3)


### PR DESCRIPTION
Fixes #13 and similar where we might want to index using a batched index:

cc @rohan-mehta-1024

```python
 def cross_entropy(logits: hax.NamedArray, labels: hax.NamedArray) -> hax.NamedArray:
        return hax.take(logits, Embed, labels)  # extract log probability of the correct token

    Embed = Axis("Embed", 10)
    Block = Axis("Block", 20)
    Batch = Axis("Batch", 30)
    logits = hax.random.uniform(PRNGKey(0), (Batch, Block, Embed))
    labels = hax.random.randint(PRNGKey(0), (Batch, Block), 0, Embed.size)

    loss = cross_entropy(logits, labels)
    assert loss.axes == (Batch, Block)
    assert jnp.alltrue(loss.array == jnp.take_along_axis(logits.array, labels.array[..., None], axis=-1)[..., 0])
```

This ends up being fairly complex to handle in the general case, but I think the result is good.