### PR TITLE
Update __bool__() in core.py

### DIFF
--- a/src/haliax/core.py
+++ b/src/haliax/core.py
@@ -587,7 +587,7 @@ class NamedArray:
         return haliax.bitwise_or(other, self)
 
     def __bool__(self) -> bool:
-        return bool(self.array)
+        return bool(self.array.all())
 
     def __complex__(self) -> complex:
         return complex(self.array)


### PR DESCRIPTION
I encountered an error here when training Levanter's Llama. The complain was `ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()`. 

Through debugging, I found that the self.array is an (non-numpy) Array. `bool(Array)` triggeres an error, but `bool(self.array.all())` would output a bool. If I understand correctly, we should use `self.array.all()` instead of `self.array.any()` here, correct?
```
-> return bool(self.array)
(Pdb) self.array
Array([[ True,  True,  True, ...,  True,  True,  True],
       [ True,  True,  True, ...,  True,  True,  True],
       [ True,  True,  True, ...,  True,  True,  True],
       ...,
       [ True,  True,  True, ...,  True,  True,  True],
       [ True,  True,  True, ...,  True,  True,  True],
       [ True,  True,  True, ...,  True,  True,  True]], dtype=bool)
(Pdb) self.array.shape
(2048, 8)
(Pdb) bool(self.array)
*** ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
(Pdb) bool(self.array.all())
True
```

I also tried training the GPT model, but this line was not triggered. I don't know exactly what was the intended input format to this line. If I miss any edge cases, please correct me. 

----
For reference, here's the full tracer of my original error:

```
Traceback (most recent call last):
  File "/home/ivan/levanter/src/levanter/main/train_lm.py", line 187, in <module>
    levanter.config.main(main)()
  File "/home/ivan/levanter/src/levanter/config.py", line 84, in wrapper_inner
    response = fn(cfg, *args, **kwargs)
  File "/home/ivan/levanter/src/levanter/main/train_lm.py", line 118, in main
    state = trainer.initial_state(training_key, model_init=lambda: config.model.build(Vocab, key=model_key))
  File "/home/ivan/levanter/src/levanter/trainer.py", line 203, in initial_state
    model, opt_state = named_jit(self._init_model_and_opt_state, self.parameter_axis_mapping)(model_init)
  File "/home/ivan/venv310/lib/python3.10/site-packages/haliax/partitioning.py", line 333, in f
    return cached_pjitted_fun(dynamic_donated, dynamic_reserved, static)
  File "<string>", line 4, in __eq__
Traceback (most recent call last):
  File "/home/ivan/levanter/src/levanter/main/train_lm.py", line 187, in <module>
    levanter.config.main(main)()
  File "/home/ivan/levanter/src/levanter/config.py", line 84, in wrapper_inner
    response = fn(cfg, *args, **kwargs)
  File "/home/ivan/levanter/src/levanter/main/train_lm.py", line 118, in main
    state = trainer.initial_state(training_key, model_init=lambda: config.model.build(Vocab, key=model_key))
  File "/home/ivan/levanter/src/levanter/trainer.py", line 203, in initial_state
    model, opt_state = named_jit(self._init_model_and_opt_state, self.parameter_axis_mapping)(model_init)
  File "/home/ivan/venv310/lib/python3.10/site-packages/haliax/partitioning.py", line 333, in f
    return cached_pjitted_fun(dynamic_donated, dynamic_reserved, static)
  File "/home/ivan/venv310/lib/python3.10/site-packages/jax/_src/traceback_util.py", line 166, in reraise_with_filtered_traceback
    return fun(*args, **kwargs)
  File "/home/ivan/venv310/lib/python3.10/site-packages/jax/_src/pjit.py", line 250, in cache_miss
    outs, out_flat, out_tree, args_flat, jaxpr = _python_pjit_helper(
  File "/home/ivan/venv310/lib/python3.10/site-packages/jax/_src/pjit.py", line 158, in _python_pjit_helper
    args_flat, _, params, in_tree, out_tree, _ = infer_params_fn(
  File "/home/ivan/venv310/lib/python3.10/site-packages/jax/_src/pjit.py", line 775, in infer_params
    return common_infer_params(pjit_info_args, *args, **kwargs)
  File "/home/ivan/venv310/lib/python3.10/site-packages/jax/_src/pjit.py", line 505, in common_infer_params
    jaxpr, consts, canonicalized_out_shardings_flat = _pjit_jaxpr(
  File "/home/ivan/venv310/lib/python3.10/site-packages/jax/_src/pjit.py", line 973, in _pjit_jaxpr
    canonicalized_out_shardings_flat = _check_and_canonicalize_out_shardings(
  File "/home/ivan/venv310/lib/python3.10/site-packages/jax/_src/pjit.py", line 951, in _check_and_canonicalize_out_shardings
    out_shardings_flat = flatten_axis_resources(
  File "/home/ivan/venv310/lib/python3.10/site-packages/jax/_src/pjit.py", line 878, in flatten_axis_resources
    errors = prefix_errors(axis_tree, dummy_tree)
  File "/home/ivan/venv310/lib/python3.10/site-packages/jax/_src/tree_util.py", line 433, in prefix_errors
    return list(_prefix_error((), prefix_tree, full_tree, is_leaf))
  File "/home/ivan/venv310/lib/python3.10/site-packages/jax/_src/tree_util.py", line 907, in _prefix_error
    yield from _prefix_error((*key_path, k), t1, t2)
  File "/home/ivan/venv310/lib/python3.10/site-packages/jax/_src/tree_util.py", line 907, in _prefix_error
    yield from _prefix_error((*key_path, k), t1, t2)
  File "/home/ivan/venv310/lib/python3.10/site-packages/jax/_src/tree_util.py", line 907, in _prefix_error
    yield from _prefix_error((*key_path, k), t1, t2)
  [Previous line repeated 3 more times]
  File "/home/ivan/venv310/lib/python3.10/site-packages/jax/_src/tree_util.py", line 880, in _prefix_error
    if prefix_tree_meta != full_tree_meta:
  File "<string>", line 4, in __eq__
  File "/home/ivan/venv310/lib/python3.10/site-packages/haliax/core.py", line 590, in __bool__
    return bool(self.array)
  File "/home/ivan/venv310/lib/python3.10/site-packages/jax/_src/array.py", line 257, in __bool__
    return bool(self._value)
jax._src.traceback_util.UnfilteredStackTrace: ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()

The stack trace below excludes JAX-internal frames.
The preceding is the original exception that occurred, unmodified.
```

Here is the debugging on Levanter side:

```
> /home/ivan/levanter/src/levanter/main/train_lm.py(118)main()
-> state = trainer.initial_state(training_key, model_init=lambda: config.model.build(Vocab, key=model_key))
(Pdb) training_key
Array([2467461003, 3840466878], dtype=uint32)

# trainer.py
(Pdb) self.parameter_axis_mapping
{'mlp': 'model', 'heads': 'model', 'batch': 'data', 'embed': 'data'}
(Pdb) self._init_model_and_opt_state
<bound method Trainer._init_model_and_opt_state of <levanter.trainer.Trainer object at 0x7f657f9b78e0>>

# Haliax.core
-> return bool(self.array)
(Pdb) self.array
Array([[ True,  True,  True, ...,  True,  True,  True],
       [ True,  True,  True, ...,  True,  True,  True],
       [ True,  True,  True, ...,  True,  True,  True],
       ...,
       [ True,  True,  True, ...,  True,  True,  True],
       [ True,  True,  True, ...,  True,  True,  True],
       [ True,  True,  True, ...,  True,  True,  True]], dtype=bool)
(Pdb) self.array.shape
(2048, 8)
(Pdb)
```
