### PR TITLE
`haliax.debug.diagnose_common_issues`

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -1,0 +1,11 @@
+# Tips and FAQ
+
+See also the [Equinox FAQ](https://docs.kidger.site/equinox/faq/)
+
+## Tip 1: `hax.debug.diagnose_common_issues`
+
+`hax.debug.diagnose_common_issues` is a function that will raise an exception if it detects problems with your module.
+Currently, we diagnose:
+
+* Reuse of arrays or NamedArrays in a field. [Equinox modules must be trees.](https://docs.kidger.site/equinox/faq/#a-module-saved-in-two-places-has-become-two-independent-copies)
+* Use of arrays or NamedArrays in a static field. Static data in JAX/Equinox must be hashable, and arrays are not hashable.

--- a/src/haliax/__init__.py
+++ b/src/haliax/__init__.py
@@ -5,6 +5,7 @@ import jax
 import jax.numpy as jnp
 from jax._src.typing import DTypeLike
 
+import haliax.debug as debug
 import haliax.nn as nn
 import haliax.random as random
 import haliax.tree_util as tree_util
@@ -808,6 +809,7 @@ concat_axis_specs = concat_axes
 
 
 __all__ = [
+    "debug",
     "random",
     "tree_util",
     "nn",

--- a/src/haliax/_src/util.py
+++ b/src/haliax/_src/util.py
@@ -1,0 +1,55 @@
+from typing import Callable, MutableMapping, Sequence, Type, TypeVar
+
+
+T = TypeVar("T")
+py_slice = slice
+slice_t = Type[slice]
+
+
+def index_where(pred: Callable[[T], bool], xs: Sequence[T]) -> int:
+    for i, x in enumerate(xs):
+        if pred(x):
+            return i
+    raise ValueError("No element satisfies predicate")
+
+
+class IdentityMap(MutableMapping):
+    """Map that compares keys by identity.
+
+    This is a map that compares keys by identity instead of equality. It is
+    useful for storing objects that are not hashable or that should be compared
+    by identity.
+
+    This is a mutable mapping, but it does not support the ``__hash__`` method
+    and therefore cannot be used as a dictionary key or as an element of another
+    set.
+    """
+
+    def __init__(self, iterable=None):
+        self._data = {}
+        if iterable is not None:
+            self.update(iterable)
+
+    def __contains__(self, key):
+        return id(key) in self._data
+
+    def __getitem__(self, key):
+        return self._data[id(key)][1]
+
+    def __setitem__(self, key, value):
+        self._data[id(key)] = [key, value]
+
+    def __delitem__(self, key):
+        del self._data[id(key)]
+
+    def __iter__(self):
+        return (x[0] for x in self._data.values())
+
+    def __len__(self):
+        return len(self._data)
+
+    def __repr__(self):
+        return f"IdentityMap({list(repr(x) for x in self._data.values())})"
+
+    def __str__(self):
+        return f"IdentityMap({list(str(x) for x in self._data.values())})"

--- a/src/haliax/axis.py
+++ b/src/haliax/axis.py
@@ -2,7 +2,9 @@ import typing
 from dataclasses import dataclass
 from typing import Dict, List, Mapping, Optional, Sequence, Tuple, Union, overload
 
-from haliax.util import ensure_tuple, index_where
+from haliax.util import ensure_tuple
+
+from ._src.util import index_where
 
 
 @dataclass(frozen=True)

--- a/src/haliax/core.py
+++ b/src/haliax/core.py
@@ -14,8 +14,9 @@ import numpy as np
 import haliax
 import haliax.axis
 from haliax.jax_utils import is_jax_array_like
-from haliax.util import ensure_tuple, index_where, py_slice, slice_t
+from haliax.util import ensure_tuple
 
+from ._src.util import index_where, py_slice, slice_t
 from .axis import Axis, AxisSelection, AxisSelector, AxisSpec, eliminate_axes, selects_axis, union_axes
 from .types import IntScalar, PrecisionLike, Scalar
 

--- a/src/haliax/debug.py
+++ b/src/haliax/debug.py
@@ -1,0 +1,117 @@
+import dataclasses
+from typing import List, Tuple, Union
+
+import equinox as eqx
+import jax.numpy as jnp
+import jax.tree_util as jtu
+
+from haliax.core import NamedArray
+from haliax.util import IdentityMap, is_jax_or_hax_array_like
+
+
+ArrayLike = Union[jnp.ndarray, NamedArray]
+
+
+def describe_array(arr):
+    if isinstance(arr, NamedArray):
+        return f"NamedArray(axes={arr.axes}, dtype={arr.dtype})"
+    else:
+        return f"ndarray(shape={arr.shape}, dtype={arr.dtype})"
+
+
+class ModuleProblems(Exception):
+    def __init__(self):
+        self.reused_arrays: List[Tuple[ArrayLike, List]] = []
+        self.static_arrays: List[str] = []
+
+    def __bool__(self):
+        return bool(self.reused_arrays or self.static_arrays)
+
+    def __str__(self):
+        if not self:
+            return "No problems found"
+        else:
+            return "\n".join(
+                [
+                    "Found some problems with your module:",
+                    *self._format_reused_arrays(),
+                    *self._format_static_arrays(),
+                ]
+            )
+
+    def _format_reused_arrays(self):
+        return [f"  Reused array {describe_array(arr)} at paths {paths}" for arr, paths in self.reused_arrays]
+
+    def _format_static_arrays(self):
+        return [f"  Static array at field {field}" for field in self.static_arrays]
+
+
+def diagnose_common_issues(module: eqx.Module):
+    """
+    Checks for common issues in a module, such as reused arrays and static arrays.
+    Equinox modules (and therefore Haliax modules) should not have arrays that are stored
+    in multiple places, and should not have arrays stored as static fields.
+
+    We'll add more checks here as we find them.
+
+    Args:
+        module:  The module to check for problems
+
+    Returns:
+        None
+
+    Raises:
+        ModuleProblems: if any problems are found
+
+    """
+
+    problems = ModuleProblems()
+    _check_for_reused_arrays(problems, module)
+    _check_for_static_arrays(problems, module)
+
+    if problems:
+        raise problems
+
+    # just in case we missed anything, raise equinox's errors:
+    eqx.tree_check(module)
+
+
+def _check_for_reused_arrays(problems, module):
+    used_arrays = IdentityMap[ArrayLike, List[str]]()
+
+    path_leaves, _ = jtu.tree_flatten_with_path(module, is_leaf=is_jax_or_hax_array_like)
+
+    for path, leaf in path_leaves:
+        if is_jax_or_hax_array_like(leaf):
+            if leaf in used_arrays:
+                used_arrays[leaf].append(jtu.keystr(path))
+            else:
+                used_arrays[leaf] = [jtu.keystr(path)]
+
+    for arr, paths in used_arrays.items():
+        if len(paths) > 1:
+            problems.reused_arrays.append((arr, paths))
+
+
+def _check_for_static_arrays(problems, module):
+    static_arrays = []
+
+    def recurse(module, path):
+        if isinstance(module, eqx.Module):
+            for field in dataclasses.fields(module):
+                value = getattr(module, field.name)
+                if field.metadata.get("static", False) and is_jax_or_hax_array_like(value):
+                    static_arrays.append(f"{path}.{field.name}")
+                else:
+                    recurse(value, f"{path}.{field.name}")
+        else:
+            leaves, _ = eqx.tree_flatten_one_level(module)
+            if leaves != [module]:
+                leaves_with_names = jtu.tree_leaves_with_path(module, is_leaf=lambda x: x in leaves)
+                for name, leaf in leaves_with_names:
+                    recurse(leaf, f"{path}{name}")
+
+    recurse(module, "")
+
+    if static_arrays:
+        problems.static_arrays.extend(static_arrays)

--- a/src/haliax/debug.py
+++ b/src/haliax/debug.py
@@ -6,7 +6,9 @@ import jax.numpy as jnp
 import jax.tree_util as jtu
 
 from haliax.core import NamedArray
-from haliax.util import IdentityMap, is_jax_or_hax_array_like
+from haliax.util import is_jax_or_hax_array_like
+
+from ._src.util import IdentityMap
 
 
 ArrayLike = Union[jnp.ndarray, NamedArray]

--- a/src/haliax/hof.py
+++ b/src/haliax/hof.py
@@ -8,11 +8,12 @@ import jax
 import jax.lax as lax
 from jaxtyping import PyTree
 
+from ._src.util import index_where
 from .axis import Axis, AxisSelector, selects_axis
 from .core import NamedArray
 from .jax_utils import Static, broadcast_prefix, is_jax_array_like
 from .partitioning import physical_axis_name
-from .util import index_where, is_jax_or_hax_array_like, is_named_array
+from .util import is_jax_or_hax_array_like, is_named_array
 
 
 BoolAxisSpec = Union[bool, Callable[[Any], bool]]

--- a/src/haliax/util.py
+++ b/src/haliax/util.py
@@ -1,14 +1,9 @@
-from typing import Callable, MutableMapping, Sequence, Tuple, Type, TypeAlias, TypeVar, Union
+from typing import Sequence, Tuple, TypeAlias, TypeVar, Union
 
 from haliax.jax_utils import is_jax_array_like
 
 
 T = TypeVar("T")
-
-
-py_slice = slice
-
-slice_t = Type[slice]
 
 Unspecified: TypeAlias = type("NotSpecified", (), {})  # type: ignore
 UNSPECIFIED = Unspecified()
@@ -50,62 +45,9 @@ def is_jax_or_hax_array_like(x):
     return is_jax_array_like(x) or is_named_array(x)
 
 
-def index_where(pred: Callable[[T], bool], xs: Sequence[T]) -> int:
-    for i, x in enumerate(xs):
-        if pred(x):
-            return i
-    raise ValueError("No element satisfies predicate")
-
-
-class IdentityMap(MutableMapping):
-    """Map that compares keys by identity.
-
-    This is a map that compares keys by identity instead of equality. It is
-    useful for storing objects that are not hashable or that should be compared
-    by identity.
-
-    This is a mutable mapping, but it does not support the ``__hash__`` method
-    and therefore cannot be used as a dictionary key or as an element of another
-    set.
-    """
-
-    def __init__(self, iterable=None):
-        self._data = {}
-        if iterable is not None:
-            self.update(iterable)
-
-    def __contains__(self, key):
-        return id(key) in self._data
-
-    def __getitem__(self, key):
-        return self._data[id(key)][1]
-
-    def __setitem__(self, key, value):
-        self._data[id(key)] = [key, value]
-
-    def __delitem__(self, key):
-        del self._data[id(key)]
-
-    def __iter__(self):
-        return (x[0] for x in self._data.values())
-
-    def __len__(self):
-        return len(self._data)
-
-    def __repr__(self):
-        return f"IdentityMap({list(repr(x) for x in self._data.values())})"
-
-    def __str__(self):
-        return f"IdentityMap({list(str(x) for x in self._data.values())})"
-
-
 __all__ = [
     "is_named_array",
     "ensure_tuple",
     "StringHolderEnum",
     "is_jax_or_hax_array_like",
-    "index_where",
-    "slice_t",
-    "py_slice",
-    "IdentityMap",
 ]

--- a/src/haliax/util.py
+++ b/src/haliax/util.py
@@ -1,4 +1,4 @@
-from typing import Callable, Sequence, Tuple, Type, TypeAlias, TypeVar, Union
+from typing import Callable, MutableMapping, Sequence, Tuple, Type, TypeAlias, TypeVar, Union
 
 from haliax.jax_utils import is_jax_array_like
 
@@ -57,6 +57,48 @@ def index_where(pred: Callable[[T], bool], xs: Sequence[T]) -> int:
     raise ValueError("No element satisfies predicate")
 
 
+class IdentityMap(MutableMapping):
+    """Map that compares keys by identity.
+
+    This is a map that compares keys by identity instead of equality. It is
+    useful for storing objects that are not hashable or that should be compared
+    by identity.
+
+    This is a mutable mapping, but it does not support the ``__hash__`` method
+    and therefore cannot be used as a dictionary key or as an element of another
+    set.
+    """
+
+    def __init__(self, iterable=None):
+        self._data = {}
+        if iterable is not None:
+            self.update(iterable)
+
+    def __contains__(self, key):
+        return id(key) in self._data
+
+    def __getitem__(self, key):
+        return self._data[id(key)][1]
+
+    def __setitem__(self, key, value):
+        self._data[id(key)] = [key, value]
+
+    def __delitem__(self, key):
+        del self._data[id(key)]
+
+    def __iter__(self):
+        return (x[0] for x in self._data.values())
+
+    def __len__(self):
+        return len(self._data)
+
+    def __repr__(self):
+        return f"IdentityMap({list(repr(x) for x in self._data.values())})"
+
+    def __str__(self):
+        return f"IdentityMap({list(str(x) for x in self._data.values())})"
+
+
 __all__ = [
     "is_named_array",
     "ensure_tuple",
@@ -65,4 +107,5 @@ __all__ = [
     "index_where",
     "slice_t",
     "py_slice",
+    "IdentityMap",
 ]

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,0 +1,96 @@
+import equinox as eqx
+import jax.numpy as jnp
+import pytest
+
+import haliax as hax
+
+
+def test_diagnose_common_issues_repeated():
+    class M(eqx.Module):
+        a: jnp.ndarray = eqx.field()
+        b: jnp.ndarray = eqx.field()
+
+        def __init__(self):
+            super().__init__()
+            self.a = jnp.zeros(1)
+            self.b = self.a
+
+    try:
+        hax.debug.diagnose_common_issues(M())
+        pytest.fail("Should have raised an exception")
+    except hax.debug.ModuleProblems as e:
+        assert len(e.reused_arrays) == 1
+        assert len(e.static_arrays) == 0
+
+
+def test_diagnose_common_issues_repeated_nested():
+    class M(eqx.Module):
+        a: jnp.ndarray = eqx.field()
+        b: jnp.ndarray = eqx.field()
+
+        def __init__(self):
+            super().__init__()
+            self.a = jnp.zeros(1)
+            self.b = self.a
+
+    class N(eqx.Module):
+        m: M = eqx.field()
+        c: jnp.ndarray = eqx.field()
+
+        def __init__(self):
+            super().__init__()
+            self.m = M()
+            self.c = self.m.a
+
+    try:
+        hax.debug.diagnose_common_issues(N())
+        pytest.fail("Should have raised an exception")
+    except hax.debug.ModuleProblems as e:
+        assert len(e.reused_arrays) == 1
+        assert e.reused_arrays[0][1] == [".m.a", ".m.b", ".c"]
+        assert len(e.static_arrays) == 0
+
+
+def test_diagnose_common_issues_static():
+    class M(eqx.Module):
+        a: jnp.ndarray = eqx.static_field()
+        b: hax.NamedArray = eqx.static_field()
+
+        def __init__(self):
+            super().__init__()
+            self.a = jnp.zeros(1)
+            self.b = hax.named(jnp.zeros(3), "a")
+
+    try:
+        hax.debug.diagnose_common_issues(M())
+        pytest.fail("Should have raised an exception")
+    except hax.debug.ModuleProblems as e:
+        assert len(e.reused_arrays) == 0
+        assert len(e.static_arrays) == 2
+
+
+def test_diagnose_common_issues_static_nested():
+    class M(eqx.Module):
+        a: jnp.ndarray = eqx.static_field()
+        b: hax.NamedArray = eqx.static_field()
+
+        def __init__(self):
+            super().__init__()
+            self.a = jnp.zeros(1)
+            self.b = hax.named(jnp.zeros(3), "a")
+
+    class N(eqx.Module):
+        m: M = eqx.field()
+        c: jnp.ndarray = eqx.field()
+
+        def __init__(self):
+            super().__init__()
+            self.m = M()
+            self.c = self.m.a
+
+    try:
+        hax.debug.diagnose_common_issues(N())
+        pytest.fail("Should have raised an exception")
+    except hax.debug.ModuleProblems as e:
+        assert len(e.reused_arrays) == 0
+        assert len(e.static_arrays) == 2


### PR DESCRIPTION
`hax.debug.diagnose_common_issues` is a function that will raise an exception if it detects problems with your module.
Currently, we diagnose:

* Reuse of arrays or NamedArrays in a field. [Equinox modules must be trees.](https://docs.kidger.site/equinox/faq/#a-module-saved-in-two-places-has-become-two-independent-copies)
* Use of arrays or NamedArrays in a static field. Static data in JAX/Equinox must be hashable, and arrays are not hashable.

I'll probably call this by default in Levanter