### PR TITLE
added custom wrapper for jax.lax.top_k in new file

### DIFF
--- a/src/haliax/__init__.py
+++ b/src/haliax/__init__.py
@@ -977,4 +977,5 @@ __all__ = [
     "selects_axis",
     "concat_axes",
     "concat_axis_specs",
+    "top_k",
 ]

--- a/src/haliax/__init__.py
+++ b/src/haliax/__init__.py
@@ -36,6 +36,7 @@ from .core import (
 from .hof import fold, map, scan, vmap
 from .ops import clip, isclose, pad_left, trace, tril, triu, where
 from .partitioning import auto_sharded, axis_mapping, fsdp, named_jit, shard_with_axis_mapping
+from .specialized_fns import top_k
 from .types import Scalar
 from .wrap import (
     ReductionFunction,

--- a/src/haliax/specialized_fns.py
+++ b/src/haliax/specialized_fns.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import jax
 import jax.numpy as jnp
 
@@ -5,7 +7,7 @@ from .axis import Axis, AxisSelector
 from .core import NamedArray
 
 
-def top_k(arr: NamedArray, axis: AxisSelector, k: int) -> NamedArray:
+def top_k(arr: NamedArray, axis: AxisSelector, k: int, new_axis: Optional[AxisSelector] = None) -> NamedArray:
     pos = arr._lookup_indices(axis)
     if pos is None:
         raise ValueError(f"Axis {axis} not found in {arr}")
@@ -13,7 +15,11 @@ def top_k(arr: NamedArray, axis: AxisSelector, k: int) -> NamedArray:
     values, _ = jax.lax.top_k(new_array, k=k)
     values = jnp.moveaxis(values, -1, pos)  # move axis back to its original position
 
-    axis = arr.resolve_axis(axis)
-    new_axis = Axis(f"top_{k}_of_{axis.name}", size=k)
+    if new_axis is None:
+        axis = arr.resolve_axis(axis)
+        new_axis = axis.resize(k)
+    elif isinstance(new_axis, str):
+        new_axis = Axis(new_axis, k)
+
     updated_axes = arr.axes[:pos] + (new_axis,) + arr.axes[pos + 1 :]
     return NamedArray(values, updated_axes)

--- a/src/haliax/specialized_fns.py
+++ b/src/haliax/specialized_fns.py
@@ -1,0 +1,19 @@
+import jax
+import jax.numpy as jnp
+
+from .axis import Axis, AxisSelector
+from .core import NamedArray
+
+
+def top_k(arr: NamedArray, axis: AxisSelector, k: int) -> NamedArray:
+    pos = arr._lookup_indices(axis)
+    if pos is None:
+        raise ValueError(f"Axis {axis} not found in {arr}")
+    new_array = jnp.moveaxis(arr.array, pos, -1)  # move axis to the last position
+    values, _ = jax.lax.top_k(new_array, k=k)
+    values = jnp.moveaxis(values, -1, pos)  # move axis back to its original position
+
+    axis = arr.resolve_axis(axis)
+    new_axis = Axis(f"top_{k}_of_{axis.name}", size=k)
+    updated_axes = arr.axes[:pos] + (new_axis,) + arr.axes[pos + 1 :]
+    return NamedArray(values, updated_axes)

--- a/tests/test_specialized_fns.py
+++ b/tests/test_specialized_fns.py
@@ -1,0 +1,25 @@
+import jax
+import jax.numpy as jnp
+
+import haliax.specialized_fns as hfns
+from haliax import Axis, NamedArray
+
+
+def test_top_k():
+    H = Axis("H", 5)
+    W = Axis("W", 6)
+    D = Axis("D", 7)
+
+    rand = jax.random.uniform(jax.random.PRNGKey(0), (H.size, W.size, D.size))
+    n_rand = NamedArray(rand, (H, W, D))
+
+    assert hfns.top_k(n_rand, D, 2).array.shape == (H.size, W.size, 2)
+    assert jnp.all(
+        jnp.equal(jax.lax.top_k(rand, 2)[0], hfns.top_k(n_rand, D, 2).array)
+    )  # test that selecting last axis is same as default
+
+    for idx, i in enumerate(n_rand.axes):  # then test selecting all axes
+        t = jnp.transpose(rand, (*range(idx), *range(idx + 1, len(n_rand.axes)), idx))
+        t = jax.lax.top_k(t, 2)[0]
+        t = jnp.moveaxis(t, -1, idx)
+        assert jnp.all(jnp.equal(t, hfns.top_k(n_rand, i, 2).array))


### PR DESCRIPTION
## Description
Added a custom wrapper for jax.lax.top_k in a new file `specialized_fns.py` – probably a bad name, but did not know what else to use. Should likely be renamed in the future. 

## Fixes Issues
#32 

## Unit test coverage
Tests the function over each axis of a random tensor and compares against the corresponding output for jax.lax.top_k.

## Known breaking changes/behaviors
N/A