### PR TITLE
Fix pspec method for levanter

### DIFF
--- a/src/haliax/partitioning.py
+++ b/src/haliax/partitioning.py
@@ -3,6 +3,7 @@ import functools
 import threading
 import typing
 import warnings
+from itertools import chain
 from math import prod
 from typing import Callable, ContextManager, Mapping, Optional, ParamSpec, Sequence, TypeVar, Union
 
@@ -585,7 +586,7 @@ def sharding_for_axis(
 def pspec_for_axis(axis: AxisSelection, mapping: Optional[ResourceMapping] = None) -> PartitionSpec:
     """Get the PartitionSpec for a single axis"""
     axis = ensure_tuple(axis)
-    return PartitionSpec(*(physical_axis_name(a, mapping) for a in axis))
+    return PartitionSpec(*chain(physical_axis_name(a, mapping) for a in axis))
 
 
 def round_axis_for_partitioning(axis: Axis, mapping: Optional[ResourceMapping] = None) -> Axis:

--- a/src/haliax/partitioning.py
+++ b/src/haliax/partitioning.py
@@ -589,9 +589,7 @@ def pspec_for_axis(axis: AxisSelection, mapping: Optional[ResourceMapping] = Non
     phys_axes = []
     for a in axis:
         pa = physical_axis_name(a, mapping)
-        if pa is None:
-            continue
-        elif isinstance(pa, str):
+        if pa is None or isinstance(pa, str):
             phys_axes.append(pa)
         else:
             # I have no way to resolve the mypy check :)

--- a/src/haliax/partitioning.py
+++ b/src/haliax/partitioning.py
@@ -38,6 +38,7 @@ class ResourceAxis(StringHolderEnum):
 
     MODEL = "model"
     DATA = "data"
+    REPLICA = "replica"
 
 
 class _ResourceMappingHolder:

--- a/src/haliax/partitioning.py
+++ b/src/haliax/partitioning.py
@@ -586,7 +586,19 @@ def sharding_for_axis(
 def pspec_for_axis(axis: AxisSelection, mapping: Optional[ResourceMapping] = None) -> PartitionSpec:
     """Get the PartitionSpec for a single axis"""
     axis = ensure_tuple(axis)
-    return PartitionSpec(*chain(physical_axis_name(a, mapping) for a in axis))
+    phys_axes = []
+    for a in axis:
+        pa = physical_axis_name(a, mapping)
+        if pa is None:
+            continue
+        elif isinstance(pa, str):
+            phys_axes.append(pa)
+        else:
+            # I have no way to resolve the mypy check :)
+            for i in pa:
+                phys_axes.append(i)
+
+    return PartitionSpec(*phys_axes)
 
 
 def round_axis_for_partitioning(axis: Axis, mapping: Optional[ResourceMapping] = None) -> Axis:


### PR DESCRIPTION
Handles the case when one logical axis maps to a tuple of (multiple) physical axes.