### PR TITLE
Changed Linear to rename In and Out to avoid conflicting names (fixes #53)

### DIFF
--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -157,3 +157,15 @@ def test_linear_has_no_function_leaves_by_default():
 
     hax_linear = hax.nn.Linear.init((H, C, W), E, key=jrandom.PRNGKey(0))
     assert all(not isinstance(v, Callable) for v in jax.tree_util.tree_leaves(hax_linear))  # type: ignore
+
+
+def test_linear_between_axes_of_same_name():
+    key = jrandom.PRNGKey(0)
+    H = Axis("H", 10)
+    A1 = Axis("A", 12)
+    A2 = Axis("A", 14)
+
+    hax_linear = hax.nn.Linear.init((H, A1), (H, A2), key=key)
+    x = hax.random.uniform(key, (H, A1))
+    y = hax_linear(x)
+    assert y.axes == (H, A2)


### PR DESCRIPTION
It's a pretty small pull request. The only changes are to `src/haliax/nn/linear.py` and an added test at `tests/test_nn.py`.

The change in `linear.py` is to make Linear rename the In axis name(s) to end in "_in" and the Out axis name(s) to end in "_out" when creating the weight/bias tensors. When Linear is called, it now renames the inputs and outputs accordingly.

The added test in `test_nn.py` makes sure that a Linear module can be created with conflicting axes' names in In and Out.