### PR TITLE
Refactor: Modernize typing to use | and collections.abc

### DIFF
--- a/src/haliax/__init__.py
+++ b/src/haliax/__init__.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Optional, Sequence
+from typing import Sequence
 
 import jax
 import jax.numpy as jnp
@@ -83,21 +83,21 @@ A = typing.TypeVar("A", Scalar, NamedArray, jnp.ndarray)
 
 
 # creation routines
-def zeros(shape: AxisSpec, dtype: Optional[DTypeLike] = None) -> NamedArray:
+def zeros(shape: AxisSpec, dtype: DTypeLike | None = None) -> NamedArray:
     """Creates a NamedArray with all elements set to 0"""
     if dtype is None:
         dtype = jnp.float32
     return full(shape, 0, dtype)
 
 
-def ones(shape: AxisSpec, dtype: Optional[DTypeLike] = None) -> NamedArray:
+def ones(shape: AxisSpec, dtype: DTypeLike | None = None) -> NamedArray:
     """Creates a NamedArray with all elements set to 1"""
     if dtype is None:
         dtype = jnp.float32
     return full(shape, 1, dtype)
 
 
-def full(shape: AxisSpec, fill_value: T, dtype: Optional[DTypeLike] = None) -> NamedArray:
+def full(shape: AxisSpec, fill_value: T, dtype: DTypeLike | None = None) -> NamedArray:
     """Creates a NamedArray with all elements set to `fill_value`"""
     if isinstance(shape, Axis):
         return NamedArray(jnp.full(shape=shape.size, fill_value=fill_value, dtype=dtype), (shape,))
@@ -116,12 +116,12 @@ def ones_like(a: NamedArray, dtype=None) -> NamedArray:
     return NamedArray(jnp.ones_like(a.array, dtype=dtype), a.axes)
 
 
-def full_like(a: NamedArray, fill_value: T, dtype: Optional[DTypeLike] = None) -> NamedArray:
+def full_like(a: NamedArray, fill_value: T, dtype: DTypeLike | None = None) -> NamedArray:
     """Creates a NamedArray with all elements set to `fill_value`"""
     return NamedArray(jnp.full_like(a.array, fill_value, dtype=dtype), a.axes)
 
 
-def arange(axis: AxisSpec, *, start=0, step=1, dtype: Optional[DTypeLike] = None) -> NamedArray:
+def arange(axis: AxisSpec, *, start=0, step=1, dtype: DTypeLike | None = None) -> NamedArray:
     """
     Version of jnp.arange that returns a NamedArray.
 
@@ -157,7 +157,7 @@ def arange(axis: AxisSpec, *, start=0, step=1, dtype: Optional[DTypeLike] = None
 
 # TODO: add overrides for arraylike start/stop to linspace, logspace, geomspace
 def linspace(
-    axis: AxisSelector, *, start: float, stop: float, endpoint: bool = True, dtype: Optional[DTypeLike] = None
+    axis: AxisSelector, *, start: float, stop: float, endpoint: bool = True, dtype: DTypeLike | None = None
 ) -> NamedArray:
     """
     Version of jnp.linspace that returns a NamedArray.
@@ -175,7 +175,7 @@ def logspace(
     stop: float,
     endpoint: bool = True,
     base: float = 10.0,
-    dtype: Optional[DTypeLike] = None,
+    dtype: DTypeLike | None = None,
 ) -> NamedArray:
     """
     Version of jnp.logspace that returns a NamedArray.
@@ -187,7 +187,7 @@ def logspace(
 
 
 def geomspace(
-    axis: AxisSelector, *, start: float, stop: float, endpoint: bool = True, dtype: Optional[DTypeLike] = None
+    axis: AxisSelector, *, start: float, stop: float, endpoint: bool = True, dtype: DTypeLike | None = None
 ) -> NamedArray:
     """
     Version of jnp.geomspace that returns a NamedArray.
@@ -209,7 +209,7 @@ def stack(axis: AxisSelector, arrays: Sequence[NamedArray]) -> NamedArray:
 
 
 def repeat(
-    a: NamedArray, repeats: int | jnp.ndarray, axis: AxisSelector, total_repeat_length: Optional[int] = None
+    a: NamedArray, repeats: int | jnp.ndarray, axis: AxisSelector, total_repeat_length: int | None = None
 ) -> NamedArray:
     """Version of [jax.numpy.repeat][] that returns a NamedArray"""
     index = a._lookup_indices(axis)
@@ -528,84 +528,84 @@ def trunc(a: A) -> A:
 
 
 # Reduction functions
-def all(array: NamedArray, axis: Optional[AxisSelection] = None, *, where: Optional[NamedArray] = None) -> NamedArray:
+def all(array: NamedArray, axis: AxisSelection | None = None, *, where: NamedArray | None = None) -> NamedArray:
     """
     Named version of [jax.numpy.all](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.all.html#jax.numpy.all).
     """
     return wrap_reduction_call(jnp.all, array, axis, where, single_axis_only=False, supports_where=True)
 
 
-def amax(array: NamedArray, axis: Optional[AxisSelection] = None, *, where: Optional[NamedArray] = None) -> NamedArray:
+def amax(array: NamedArray, axis: AxisSelection | None = None, *, where: NamedArray | None = None) -> NamedArray:
     """
     Aliax for max. See max for details.
     """
     return wrap_reduction_call(jnp.amax, array, axis, where, single_axis_only=False, supports_where=True)
 
 
-def any(array: NamedArray, axis: Optional[AxisSelection] = None, *, where: Optional[NamedArray] = None) -> NamedArray:
+def any(array: NamedArray, axis: AxisSelection | None = None, *, where: NamedArray | None = None) -> NamedArray:
     """True if any elements along a given axis or axes are True. If axis is None, any elements are True."""
     return wrap_reduction_call(jnp.any, array, axis, where, single_axis_only=False, supports_where=True)
 
 
-def argmax(array: NamedArray, axis: Optional[AxisSelector]) -> NamedArray:
+def argmax(array: NamedArray, axis: AxisSelector | None) -> NamedArray:
     return wrap_reduction_call(jnp.argmax, array, axis, None, single_axis_only=True, supports_where=False)
 
 
-def argmin(array: NamedArray, axis: Optional[AxisSelector]) -> NamedArray:
+def argmin(array: NamedArray, axis: AxisSelector | None) -> NamedArray:
     return wrap_reduction_call(jnp.argmin, array, axis, None, single_axis_only=True, supports_where=False)
 
 
-def max(array: NamedArray, axis: Optional[AxisSelection] = None, *, where: Optional[NamedArray] = None) -> NamedArray:
+def max(array: NamedArray, axis: AxisSelection | None = None, *, where: NamedArray | None = None) -> NamedArray:
     return wrap_reduction_call(jnp.max, array, axis, where, single_axis_only=False, supports_where=True)
 
 
 def mean(
     array: NamedArray,
-    axis: Optional[AxisSelection] = None,
+    axis: AxisSelection | None = None,
     *,
-    where: Optional[NamedArray] = None,
-    dtype: Optional[DTypeLike] = None,
+    where: NamedArray | None = None,
+    dtype: DTypeLike | None = None,
 ) -> NamedArray:
     return wrap_reduction_call(jnp.mean, array, axis, where, single_axis_only=False, supports_where=True, dtype=dtype)
 
 
-def min(array: NamedArray, axis: Optional[AxisSelection] = None, *, where: Optional[NamedArray] = None) -> NamedArray:
+def min(array: NamedArray, axis: AxisSelection | None = None, *, where: NamedArray | None = None) -> NamedArray:
     return wrap_reduction_call(jnp.min, array, axis, where, single_axis_only=False, supports_where=True)
 
 
 def prod(
     array: NamedArray,
-    axis: Optional[AxisSelection] = None,
+    axis: AxisSelection | None = None,
     *,
-    where: Optional[NamedArray] = None,
-    dtype: Optional[DTypeLike] = None,
+    where: NamedArray | None = None,
+    dtype: DTypeLike | None = None,
 ) -> NamedArray:
     return wrap_reduction_call(jnp.prod, array, axis, where, single_axis_only=False, supports_where=True, dtype=dtype)
 
 
 def std(
     array: NamedArray,
-    axis: Optional[AxisSelection] = None,
+    axis: AxisSelection | None = None,
     *,
-    where: Optional[NamedArray] = None,
+    where: NamedArray | None = None,
     ddof: int = 0,
-    dtype: Optional[DTypeLike] = None,
+    dtype: DTypeLike | None = None,
 ) -> NamedArray:
     return wrap_reduction_call(
         jnp.std, array, axis, where, single_axis_only=False, supports_where=True, dtype=dtype, ddof=ddof
     )
 
 
-def ptp(array: NamedArray, axis: Optional[AxisSelection] = None, *, where: Optional[NamedArray] = None) -> NamedArray:
+def ptp(array: NamedArray, axis: AxisSelection | None = None, *, where: NamedArray | None = None) -> NamedArray:
     return wrap_reduction_call(jnp.ptp, array, axis, where, single_axis_only=False, supports_where=True)
 
 
 def product(
     array: NamedArray,
-    axis: Optional[AxisSelection] = None,
+    axis: AxisSelection | None = None,
     *,
-    where: Optional[NamedArray] = None,
-    dtype: Optional[DTypeLike] = None,
+    where: NamedArray | None = None,
+    dtype: DTypeLike | None = None,
 ) -> NamedArray:
     return wrap_reduction_call(
         jnp.product, array, axis, where, single_axis_only=False, supports_where=True, dtype=dtype
@@ -617,21 +617,21 @@ _sum = sum
 
 def sum(
     array: NamedArray,
-    axis: Optional[AxisSelection] = None,
+    axis: AxisSelection | None = None,
     *,
-    where: Optional[NamedArray] = None,
-    dtype: Optional[DTypeLike] = None,
+    where: NamedArray | None = None,
+    dtype: DTypeLike | None = None,
 ) -> NamedArray:
     return wrap_reduction_call(jnp.sum, array, axis, where, single_axis_only=False, supports_where=True, dtype=dtype)
 
 
 def var(
     array: NamedArray,
-    axis: Optional[AxisSelection] = None,
+    axis: AxisSelection | None = None,
     *,
-    where: Optional[NamedArray] = None,
+    where: NamedArray | None = None,
     ddof: int = 0,
-    dtype: Optional[DTypeLike] = None,
+    dtype: DTypeLike | None = None,
 ) -> NamedArray:
     return wrap_reduction_call(
         jnp.var, array, axis, where, single_axis_only=False, supports_where=True, dtype=dtype, ddof=ddof
@@ -641,14 +641,14 @@ def var(
 # "Normalization" functions that use an axis but don't change the shape
 
 
-def cumsum(a: NamedArray, axis: AxisSelector, *, dtype: Optional[DTypeLike] = None) -> NamedArray:
+def cumsum(a: NamedArray, axis: AxisSelector, *, dtype: DTypeLike | None = None) -> NamedArray:
     """
     Named version of [jax.numpy.cumsum](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.cumsum.html)
     """
     return wrap_axiswise_call(jnp.cumsum, a, axis, dtype=dtype, single_axis_only=True)
 
 
-def cumprod(a: NamedArray, axis: AxisSelector, dtype: Optional[DTypeLike] = None) -> NamedArray:
+def cumprod(a: NamedArray, axis: AxisSelector, dtype: DTypeLike | None = None) -> NamedArray:
     """
     Named version of [jax.numpy.cumprod](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.cumprod.html)
     """

--- a/src/haliax/_src/dot.py
+++ b/src/haliax/_src/dot.py
@@ -1,7 +1,7 @@
 import functools as ft
 import typing
 import warnings
-from typing import Dict, Optional, Tuple
+from collections.abc import Dict
 
 import jax
 import jax.numpy as jnp
@@ -25,11 +25,11 @@ from haliax.util import ensure_tuple
 # deprecated overload
 @typing.overload
 def dot(
-    axis: Optional[AxisSelection],
+    axis: AxisSelection | None,
     *arrays: NamedArray,
     precision: PrecisionLike = None,
-    preferred_element_type: Optional[DTypeLike] = None,
-    out_axes: Optional[PartialAxisSpec] = ...,
+    preferred_element_type: DTypeLike | None = None,
+    out_axes: PartialAxisSpec | None = ...,
     dot_general=jax.lax.dot_general,
 ) -> NamedArray:
     ...
@@ -38,10 +38,10 @@ def dot(
 @typing.overload
 def dot(
     *arrays: NamedArray,
-    axis: Optional[AxisSelection],
+    axis: AxisSelection | None,
     precision: PrecisionLike = None,
-    preferred_element_type: Optional[DTypeLike] = None,
-    out_axes: Optional[PartialAxisSpec] = ...,
+    preferred_element_type: DTypeLike | None = None,
+    out_axes: PartialAxisSpec | None = ...,
     dot_general=jax.lax.dot_general,
 ) -> NamedArray:
     ...
@@ -50,8 +50,8 @@ def dot(
 def dot(
     *arrays,
     precision: PrecisionLike = None,
-    preferred_element_type: Optional[DTypeLike] = None,
-    out_axes: Optional[PartialAxisSpec] = None,
+    preferred_element_type: DTypeLike | None = None,
+    out_axes: PartialAxisSpec | None = None,
     dot_general=jax.lax.dot_general,
     **kwargs,
 ) -> NamedArray:
@@ -105,8 +105,8 @@ def dot(
     # to call dot_general we need two things:
     # list of contractions and list of arrays
 
-    all_axes: Tuple[Axis, ...] = ft.reduce(union_axes, (a.axes for a in arrays), ())  # type: ignore
-    output_axes: Tuple[Axis, ...]
+    all_axes: tuple[Axis, ...] = ft.reduce(union_axes, (a.axes for a in arrays), ())  # type: ignore
+    output_axes: tuple[Axis, ...]
     if axis is None:
         # we want to contract over all the axes
         output_axes = ()

--- a/src/haliax/_src/einsum.py
+++ b/src/haliax/_src/einsum.py
@@ -1,6 +1,6 @@
 import functools
 from types import EllipsisType
-from typing import Optional, Tuple
+from collections.abc import Tuple
 
 import jax.lax
 
@@ -19,7 +19,7 @@ def einsum(
     equation: str,
     *arrays: NamedArray,
     precision: PrecisionLike = None,
-    preferred_element_type: Optional[DTypeLike] = None,
+    preferred_element_type: DTypeLike | None = None,
     _dot_general: DotGeneralOp = jax.lax.dot_general,
     **axis_aliases: AxisSelector,
 ) -> NamedArray:

--- a/src/haliax/_src/parsing.py
+++ b/src/haliax/_src/parsing.py
@@ -1,15 +1,16 @@
 import dataclasses
 from types import EllipsisType
-from typing import Mapping, NoReturn, Optional, Sequence
+from collections.abc import Mapping, Sequence
+from typing import NoReturn
 
 from haliax.axis import Axis, AxisSelector
 
 
 @dataclasses.dataclass
 class _AxisCapture:
-    binding: Optional[str] = None
+    binding: str | None = None
     axes: tuple[str, ...] = ()
-    char_range: Optional[tuple[int, int]] = None
+    char_range: tuple[int, int] | None = None
 
     def __post_init__(self):
         if len(self.axes) == 0:
@@ -22,7 +23,7 @@ class Expression:
     is_ordered: bool
 
 
-def raise_parse_error(message: str, expression: str, pos: Optional[int | tuple[int, int]]) -> NoReturn:
+def raise_parse_error(message: str, expression: str, pos: int | tuple[int, int] | None) -> NoReturn:
     """Raise a ValueError with a message and the position in the expression."""
     fmt = f"Error while parsing:\n    {expression}"
     if pos is not None:
@@ -223,13 +224,13 @@ def _parse_expression(expression: str, pos) -> tuple[Expression, int]:
 class AliasTable:
     bindings: dict[str, AxisSelector]  # names in the string to axes
 
-    def __init__(self, bindings=None):
+    def __init__(self, bindings: Mapping[str, AxisSelector] | None = None):
         if bindings is None:
             self.bindings = {}
         else:
             self.bindings = {**bindings}
 
-    def dealias_binding(self, binding: str) -> Optional[AxisSelector]:
+    def dealias_binding(self, binding: str) -> AxisSelector | None:
         return self.bindings.get(binding, None)
 
     def bind_alias(self, alias: str, axis: Axis, expr, char_range):

--- a/src/haliax/_src/scan.py
+++ b/src/haliax/_src/scan.py
@@ -1,6 +1,6 @@
 import dataclasses
 import functools as ft
-from typing import Any, Callable, Literal, ParamSpec, Protocol, Sequence, Tuple, TypeVar, Union, overload
+from typing import Any, Callable, Literal, ParamSpec, Protocol, Sequence, TypeVar, overload
 
 import equinox as eqx
 import jax
@@ -15,7 +15,7 @@ from haliax.jax_utils import is_jax_array_like, multilevel_scan, tree_checkpoint
 from haliax.util import is_jax_or_hax_array_like, is_named_array
 
 
-BoolAxisSpec = Union[bool, Callable[[Any], bool]]
+BoolAxisSpec = bool | Callable[[Any], bool]
 Carry = TypeVar("Carry")
 X = TypeVar("X", contravariant=True)
 Y = TypeVar("Y", covariant=True)
@@ -165,7 +165,7 @@ class ScanCheckpointPolicy:
             raise ValueError(f"Invalid checkpoint policy {remat_policy}")
 
     @staticmethod
-    def _mk(remat_policy: Union[bool, str, "ScanCheckpointPolicy"]) -> "ScanCheckpointPolicy":
+    def _mk(remat_policy: bool | str | "ScanCheckpointPolicy") -> "ScanCheckpointPolicy":
         if isinstance(remat_policy, ScanCheckpointPolicy):
             return remat_policy
         else:
@@ -248,7 +248,9 @@ class ScanCheckpointPolicy:
                 return None
 
 
-ScanCheckpointSpec = Union[ScanCheckpointPolicy, bool, Literal["offload", "recompute", "full", "save_all", "nested"]]
+ScanCheckpointSpec = (
+    ScanCheckpointPolicy | bool | Literal["offload", "recompute", "full", "save_all", "nested"]
+)
 
 
 @overload
@@ -500,8 +502,8 @@ def map(
     return scanned_f
 
 
-ResolvedUnnamedAxisSpec = Union[int, None]
-UnnamedAxisSpec = Union[ResolvedUnnamedAxisSpec, Callable[[Any], ResolvedUnnamedAxisSpec]]
+ResolvedUnnamedAxisSpec = int | None
+UnnamedAxisSpec = ResolvedUnnamedAxisSpec | Callable[[Any], ResolvedUnnamedAxisSpec]
 
 
 def _zero_if_array_else_none(x: Any) -> ResolvedUnnamedAxisSpec:
@@ -538,7 +540,7 @@ class _PassiveNamedArray:
     """
 
     array: jax.numpy.ndarray
-    main_axes: Tuple[Axis, ...]
+    main_axes: tuple[Axis, ...]
 
     def as_scanned_result(self, scan_axis: Axis):
         return NamedArray(self.array, (scan_axis,) + self.main_axes)

--- a/src/haliax/_src/state_dict.py
+++ b/src/haliax/_src/state_dict.py
@@ -1,7 +1,8 @@
 # Module to support torch-style "state dict" serialization via safetensors
 import dataclasses
 import typing
-from typing import Any, Optional, Sequence, TypeVar
+from typing import Any, TypeVar
+from collections.abc import Sequence
 
 import equinox as eqx
 import jax
@@ -33,7 +34,7 @@ T = TypeVar("T")
 
 
 def from_torch_compatible_state_dict(
-    t: T, state_dict: StateDict, *, unflatten: bool = True, prefix: Optional[str] = None
+    t: T, state_dict: StateDict, *, unflatten: bool = True, prefix: str | None = None
 ) -> T:
     """
     Convert a state dict to a tree that is compatible with the structure of `t`.
@@ -118,11 +119,11 @@ def with_prefix(prefix: str, leaf: None) -> str:
 
 
 @typing.overload
-def with_prefix(prefix: Optional[str], leaf: Optional[str]) -> Optional[str]:
+def with_prefix(prefix: str | None, leaf: str | None) -> str | None:
     ...
 
 
-def with_prefix(prefix: Optional[str], leaf: Optional[str]) -> Optional[str]:
+def with_prefix(prefix: str | None, leaf: str | None) -> str | None:
     """Joins two optional path strings in a way compatible with pytorch state dict serialization"""
     if prefix is None:
         return leaf
@@ -135,13 +136,13 @@ def with_prefix(prefix: Optional[str], leaf: Optional[str]) -> Optional[str]:
 class ModuleWithStateDictSerialization(eqx.Module):
     """An eqx.Module that can be serialized to a torch-style state dict."""
 
-    def to_state_dict(self, prefix: Optional[str] = None) -> StateDict:
+    def to_state_dict(self, prefix: str | None = None) -> StateDict:
         return default_eqx_module_to_state_dict(self, prefix)
 
-    def from_state_dict(self: Mod, state_dict: StateDict, prefix: Optional[str] = None) -> Mod:
+    def from_state_dict(self: Mod, state_dict: StateDict, prefix: str | None = None) -> Mod:
         return default_eqx_module_from_state_dict(self, state_dict, prefix)
 
-    def _state_dict_key_map(self) -> dict[str, Optional[str]]:
+    def _state_dict_key_map(self) -> dict[str, str | None]:
         """Returns a dict mapping eqx.Module keys to torch keys that need to be renamed for serialization"""
         return {}
 
@@ -165,7 +166,7 @@ class ModuleWithStateDictSerialization(eqx.Module):
         return self
 
 
-def from_state_dict(tree: T, state_dict: StateDict, prefix: Optional[str] = None) -> T:
+def from_state_dict(tree: T, state_dict: StateDict, prefix: str | None = None) -> T:
     """
     Given a (template) tree and a state dict, return a new tree with the same structure as the input tree, but with
     the values from the state dict.
@@ -221,7 +222,7 @@ def from_state_dict(tree: T, state_dict: StateDict, prefix: Optional[str] = None
         return state_dict.get(prefix, tree)
 
 
-def to_state_dict(tree: PyTree, prefix: Optional[str] = None) -> StateDict:
+def to_state_dict(tree: PyTree, prefix: str | None = None) -> StateDict:
     """
     Convert a PyTree to a state dict.
 
@@ -273,8 +274,8 @@ def to_state_dict(tree: PyTree, prefix: Optional[str] = None) -> StateDict:
     return state_dict
 
 
-def default_eqx_module_from_state_dict(mod: Mod, state_dict: StateDict, prefix: Optional[str] = None) -> Mod:
-    key_map: Dict[str, Optional[str]] = getattr(mod, "_state_dict_key_map", lambda: {})()  # type: ignore
+def default_eqx_module_from_state_dict(mod: Mod, state_dict: StateDict, prefix: str | None = None) -> Mod:
+    key_map: dict[str, str | None] = getattr(mod, "_state_dict_key_map", lambda: {})()  # type: ignore
     names = []
     values = []
     for field in dataclasses.fields(mod):
@@ -293,7 +294,7 @@ def default_eqx_module_from_state_dict(mod: Mod, state_dict: StateDict, prefix: 
     return eqx.tree_at(lambda m: [getattr(m, name) for name in names], mod, values)
 
 
-def default_eqx_module_to_state_dict(mod: eqx.Module, prefix: Optional[str] = None) -> StateDict:
+def default_eqx_module_to_state_dict(mod: eqx.Module, prefix: str | None = None) -> StateDict:
     """
     Convert an eqx.Module to a state dict. This is the default implementation of the to_state_dict method for
     eqx.Modules. It works by iterating over the fields of the module and calling to_state_dict on each field.
@@ -305,7 +306,7 @@ def default_eqx_module_to_state_dict(mod: eqx.Module, prefix: Optional[str] = No
 
     """
     state_dict: StateDict = {}
-    key_map: Dict[str, Optional[str]] = getattr(mod, "_state_dict_key_map", lambda: {})()  # type: ignore
+    key_map: dict[str, str | None] = getattr(mod, "_state_dict_key_map", lambda: {})()  # type: ignore
     for field in dataclasses.fields(mod):
         if field.metadata.get("static", False):
             continue
@@ -317,7 +318,7 @@ def default_eqx_module_to_state_dict(mod: eqx.Module, prefix: Optional[str] = No
     return state_dict
 
 
-def format_path_for_state_dict(prefix: Optional[str], path: Sequence) -> str:
+def format_path_for_state_dict(prefix: str | None, path: Sequence) -> str:
     res = "".join(_format_key_path_element(path_elem) for path_elem in path)
     # res will have a .
     if prefix is not None:
@@ -349,7 +350,7 @@ def _format_key_path_element(path_elem) -> str:
                 return f".{path_elem}"
 
 
-def to_numpy_state_dict(model, prefix: Optional[str] = None) -> StateDict:
+def to_numpy_state_dict(model, prefix: str | None = None) -> StateDict:
     """
     Convert a model to a state dict by first creating desharded copies of all parameters that reside in CPU
     memory.

--- a/src/haliax/_src/util.py
+++ b/src/haliax/_src/util.py
@@ -1,4 +1,5 @@
-from typing import Callable, MutableMapping, Sequence, TypeAlias, TypeVar
+from collections.abc import Callable, MutableMapping, Sequence
+from typing import TypeAlias, TypeVar
 
 
 T = TypeVar("T")


### PR DESCRIPTION
This commit updates the codebase to use the new PEP 604 type union operator `|` instead of `typing.Union` and `typing.Optional`. It also replaces aliases from `typing` (like `typing.List`, `typing.Dict`, `typing.Tuple`, `typing.Sequence`, `typing.Callable`, `typing.Mapping`) with their builtin counterparts (e.g., `list`, `dict`, `tuple`) or with types from `collections.abc` (e.g., `collections.abc.Sequence`, `collections.abc.Callable`, `collections.abc.Mapping`).

Changes have been applied to the following files:
- src/haliax/__init__.py
- src/haliax/_src/dot.py
- src/haliax/_src/einsum.py
- src/haliax/_src/parsing.py
- src/haliax/_src/scan.py
- src/haliax/_src/state_dict.py
- src/haliax/_src/util.py
- src/haliax/axis.py
- src/haliax/core.py

Further files were planned to be updated, but I am finishing up at this stage.