### PR TITLE
Improve NamedArray typing

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -1,0 +1,25 @@
+# NamedArray Type Annotations
+
+Haliax supports a lightweight syntax for specifying the axes of a `NamedArray`
+in type annotations.  Internally, `NamedArray[...]` expands to
+`Annotated[NamedArray, axes]`, so it works well with static type checkers like
+``mypy``.  The syntax mirrors normal indexing with axis names.  Some examples:
+
+```python
+from haliax import NamedArray
+
+arr: NamedArray["batch", "embed"]
+arr: NamedArray["batch embed ..."]      # starts with these axes
+arr: NamedArray["... embed"]             # ends with this axis
+arr: NamedArray["batch ... embed"]       # contains these axes in order
+arr: NamedArray[{"batch", "embed"}]      # has exactly these axes, order ignored
+arr: NamedArray[{"batch", "embed", ...}] # has at least these axes
+```
+
+At runtime you can verify that a `NamedArray` conforms to a particular
+annotation using `matches_axes`:
+
+```python
+if not arr.matches_axes(NamedArray["batch embed ..."]):
+    raise ValueError("unexpected axes")
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
     - Indexing and Slicing: 'indexing.md'
     - Rearrange: 'rearrange.md'
     - Matrix Multiplication: 'matmul.md'
+    - Type Annotations: 'typing.md'
   - Higher Order Functions:
     - Scan and Fold: 'scan.md'
     - Vectorization: 'vmap.md'

--- a/src/haliax/__init__.py
+++ b/src/haliax/__init__.py
@@ -40,6 +40,8 @@ from .axis import (
     selects_axis,
 )
 from .core import (
+    NamedArrayAxesSpec,
+    NamedArrayAxes,
     NamedArray,
     NamedOrNumeric,
     are_shape_checks_enabled,
@@ -926,6 +928,8 @@ __all__ = [
     "make_axes",
     "axis_name",
     "axis_size",
+    "NamedArrayAxesSpec",
+    "NamedArrayAxes",
     "NamedArray",
     "broadcast_to",
     "broadcast_axis",

--- a/tests/test_namedarray_typing.py
+++ b/tests/test_namedarray_typing.py
@@ -1,0 +1,43 @@
+import jax.numpy as jnp
+import haliax as hax
+from haliax import Axis, NamedArray
+import typing
+
+
+def test_namedarray_type_syntax():
+    t1 = NamedArray["batch", "embed"]
+    t2 = NamedArray["batch embed"]
+    assert typing.get_args(t1)[1] == typing.get_args(t2)[1]
+
+    t3 = NamedArray["batch embed ..."]
+    axes3 = typing.get_args(t3)[1]
+    assert axes3.before == ("batch", "embed") and axes3.subset and axes3.after == ()
+
+    t4 = NamedArray[{"batch", "embed"}]
+    axes4 = typing.get_args(t4)[1]
+    assert set(axes4.before) == {"batch", "embed"} and not axes4.ordered
+
+    t5 = NamedArray[{"batch", "embed", ...}]
+    axes5 = typing.get_args(t5)[1]
+    assert set(axes5.before) == {"batch", "embed"} and not axes5.ordered and axes5.subset
+
+    t6 = NamedArray["... embed"]
+    axes6 = typing.get_args(t6)[1]
+    assert axes6.before == () and axes6.after == ("embed",) and axes6.subset
+
+    t7 = NamedArray["batch ... embed"]
+    axes7 = typing.get_args(t7)[1]
+    assert axes7.before == ("batch",) and axes7.after == ("embed",) and axes7.subset
+
+
+def test_namedarray_runtime_check():
+    Batch = Axis("batch", 2)
+    Embed = Axis("embed", 3)
+    arr = NamedArray(jnp.zeros((Batch.size, Embed.size)), (Batch, Embed))
+    assert arr.matches_axes(NamedArray["batch", "embed"])
+    assert arr.matches_axes(NamedArray["batch embed"])
+    assert arr.matches_axes(NamedArray["batch embed ..."])
+    assert arr.matches_axes(NamedArray[{"batch", "embed"}])
+    assert arr.matches_axes(NamedArray[{"batch", "embed", ...}])
+    assert not arr.matches_axes(NamedArray["embed batch"])
+    assert not arr.matches_axes(NamedArray[{"batch", "foo", ...}])


### PR DESCRIPTION
## Summary
- implement richer NamedArrayAxes representation and parsing
- support prefix, suffix and infix ellipsis in NamedArray typing
- allow unordered specs with ellipsis
- expose runtime checks and document usage
- add tests and docs for new typing syntax
- refine type annotations with NamedArrayAxesSpec alias
- return `Annotated[NamedArray, axes]` from `NamedArray[...]` for mypy compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cefef22888331bd00e3a95cfb67c7