### PR TITLE
Implement dtype-aware NamedArray typing

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -56,6 +56,6 @@ At runtime ``matches_axes`` also checks the dtype when one is present:
 from haliax import Axis, zeros
 import haliax.typing as ht
 
-arr = zeros(Axis("batch", 4))
+arr = zeros({"batch": 4})
 assert arr.matches_axes(ht.f32["batch"])  # dtype and axes both match
 ```

--- a/docs/typing.md
+++ b/docs/typing.md
@@ -23,3 +23,39 @@ annotation using `matches_axes`:
 if not arr.matches_axes(Named["batch embed ..."]):
     raise ValueError("unexpected axes")
 ```
+
+## DType-aware annotations
+
+Sometimes it is useful to express both the axes **and** the dtype in the type
+annotation.  The :mod:`haliax.typing` module defines symbolic types for all of
+JAX's common dtypes that can be indexed just like ``Named``.  In documentation
+examples we'll use ``import haliax.typing as ht``:
+
+```python
+import haliax.typing as ht
+
+def foo(x: ht.f32["batch"]):
+    ...
+
+def bar(x: ht.i32["batch"]):
+    ...
+```
+
+For convenience the module also provides aggregate categories ``Float``,
+``Complex``, ``Int`` and ``UInt`` that match any floating point, complex,
+signed integer or unsigned integer dtype respectively:
+
+```python
+def baz(x: ht.Float["batch"]):
+    ...
+```
+
+At runtime ``matches_axes`` also checks the dtype when one is present:
+
+```python
+from haliax import Axis, zeros
+import haliax.typing as ht
+
+arr = zeros(Axis("batch", 4))
+assert arr.matches_axes(ht.f32["batch"])  # dtype and axes both match
+```

--- a/src/haliax/typing.py
+++ b/src/haliax/typing.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import typing as tp
+from dataclasses import dataclass, replace
+
+import jax.numpy as jnp
+
+from .core import NamedArray, NamedArrayAxes, _parse_namedarray_axes
+
+
+@dataclass(frozen=True)
+class DTypeCategory:
+    """Represents a dtype category such as ``float`` or ``int``."""
+
+    name: str
+    category: tp.Any
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return self.name
+
+
+def _wrap_namedarray_with_dtype(dtype):
+    class DTypeType:
+        def __class_getitem__(cls, axes_spec):
+            axes = _parse_namedarray_axes(axes_spec)
+            axes_with_dtype = replace(axes, dtype=dtype)
+            return tp.Annotated[NamedArray, axes_with_dtype]
+
+    return DTypeType
+
+
+def _wrap_namedarray_with_category(category: DTypeCategory):
+    class DTypeType:
+        def __class_getitem__(cls, axes_spec):
+            axes = _parse_namedarray_axes(axes_spec)
+            axes_with_dtype = replace(axes, dtype=category)
+            return tp.Annotated[NamedArray, axes_with_dtype]
+
+    return DTypeType
+
+
+f32 = _wrap_namedarray_with_dtype(jnp.float32)
+f64 = _wrap_namedarray_with_dtype(jnp.float64)
+f16 = _wrap_namedarray_with_dtype(jnp.float16)
+bf16 = _wrap_namedarray_with_dtype(jnp.bfloat16)
+
+i8 = _wrap_namedarray_with_dtype(jnp.int8)
+i16 = _wrap_namedarray_with_dtype(jnp.int16)
+i32 = _wrap_namedarray_with_dtype(jnp.int32)
+i64 = _wrap_namedarray_with_dtype(jnp.int64)
+
+u8 = _wrap_namedarray_with_dtype(jnp.uint8)
+u16 = _wrap_namedarray_with_dtype(jnp.uint16)
+u32 = _wrap_namedarray_with_dtype(jnp.uint32)
+u64 = _wrap_namedarray_with_dtype(jnp.uint64)
+
+bool_ = _wrap_namedarray_with_dtype(jnp.bool_)
+complex64 = _wrap_namedarray_with_dtype(jnp.complex64)
+complex128 = _wrap_namedarray_with_dtype(jnp.complex128)
+
+
+Float = _wrap_namedarray_with_category(DTypeCategory("float", jnp.floating))
+Complex = _wrap_namedarray_with_category(DTypeCategory("complex", jnp.complexfloating))
+Int = _wrap_namedarray_with_category(DTypeCategory("int", jnp.signedinteger))
+UInt = _wrap_namedarray_with_category(DTypeCategory("uint", jnp.unsignedinteger))
+
+
+__all__ = [
+    "f32",
+    "f64",
+    "f16",
+    "bf16",
+    "i8",
+    "i16",
+    "i32",
+    "i64",
+    "u8",
+    "u16",
+    "u32",
+    "u64",
+    "bool_",
+    "complex64",
+    "complex128",
+    "Float",
+    "Complex",
+    "Int",
+    "UInt",
+]

--- a/tests/test_dtype_typing.py
+++ b/tests/test_dtype_typing.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import typing
+
+import jax.numpy as jnp
+
+from haliax import Axis, NamedArray
+from haliax.typing import Float, Int, f32, i32
+
+
+def test_dtype_and_axes_annotation():
+    def foo(x: f32["batch embed"]):  # type: ignore  # noqa: F722
+        pass
+
+    ann = typing.get_args(typing.get_type_hints(foo, include_extras=True)["x"])
+    assert ann[0] is NamedArray
+    spec = ann[1]
+    assert spec.dtype == jnp.float32
+    assert spec.before == ("batch", "embed")
+
+
+def test_other_dtype_annotation():
+    def bar(x: i32["batch"]):  # type: ignore  # noqa: F722
+        pass
+
+    spec = typing.get_args(typing.get_type_hints(bar, include_extras=True)["x"])[1]
+    assert spec.dtype == jnp.int32
+    assert spec.before == ("batch",)
+
+
+def test_dtype_category_annotation_and_check():
+    def baz(x: Float["b"]):  # type: ignore  # noqa: F722
+        pass
+
+    spec = typing.get_args(typing.get_type_hints(baz, include_extras=True)["x"])[1]
+    assert str(spec.dtype) == "float"
+
+    B = Axis("b", 1)
+    arr = NamedArray(jnp.ones((B.size,), dtype=jnp.float32), (B,))
+    assert arr.matches_axes(Float["b"])  # type: ignore
+    assert not arr.matches_axes(Int["b"])  # type: ignore

--- a/tests/test_namedarray_typing.py
+++ b/tests/test_namedarray_typing.py
@@ -5,6 +5,7 @@ import typing
 import jax.numpy as jnp
 
 from haliax import Axis, Named, NamedArray
+from haliax.typing import Float, Int, f32, i32
 
 
 def test_namedarray_type_syntax():
@@ -47,3 +48,17 @@ def test_namedarray_runtime_check():
     assert arr.matches_axes(NamedArray[{"batch", "embed", ...}])
     assert not arr.matches_axes(NamedArray["embed batch"])
     assert not arr.matches_axes(NamedArray[{"batch", "foo", ...}])
+
+
+def test_namedarray_runtime_check_with_dtype():
+    Batch = Axis("batch", 2)
+    arr = NamedArray(jnp.zeros((Batch.size,), dtype=jnp.float32), (Batch,))
+    assert arr.matches_axes(f32["batch"])  # type: ignore
+    assert not arr.matches_axes(i32["batch"])  # type: ignore
+
+
+def test_namedarray_runtime_check_with_category():
+    B = Axis("batch", 1)
+    arr = NamedArray(jnp.zeros((B.size,), dtype=jnp.float32), (B,))
+    assert arr.matches_axes(Float["batch"])  # type: ignore
+    assert not arr.matches_axes(Int["batch"])  # type: ignore


### PR DESCRIPTION
## Summary
- add dtype attribute to `NamedArrayAxes` with display in `__repr__`
- support dtype checking in `matches_axes` including dtype categories
- provide dtype wrappers in `haliax.typing` and new categories `Float`, `Complex`, `Int`, `UInt`
- document dtype annotations using `import haliax.typing as ht`
- test dtype annotations and runtime checking including categories

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685f95080c08833181f6896f70fed6d3