### PR TITLE
Use JAX AbstractMesh

### DIFF
--- a/src/haliax/_src/state_dict.py
+++ b/src/haliax/_src/state_dict.py
@@ -197,7 +197,7 @@ def from_state_dict(tree: T, state_dict: StateDict, prefix: Optional[str] = None
         if isinstance(array, np.ndarray):
             mesh = partitioning._get_mesh()
             # TODO: modernize this
-            if mesh.devices.size > 1:  # this happens with the default mesh
+            if jax.device_count() > 1:  # this happens with the default mesh
                 pspec = partitioning.pspec_for_axis(tree.axes)
                 sharding = jax.sharding.NamedSharding(mesh, pspec)
                 array = jax.make_array_from_callback(tree.array.shape, sharding, lambda indices: array[indices])


### PR DESCRIPTION
## Summary
- update `_get_mesh` to use JAX `AbstractMesh`
- fix state dict logic that checked concrete mesh

## Testing
- `pre-commit run --all-files`
- `pytest tests -m "not entry and not slow and not ray"` *(fails: ModuleNotFoundError: No module named 'jax')*

------
https://chatgpt.com/codex/tasks/task_e_686c183f08048331ab258c549442f90e