### PR TITLE
Expose BlockSeq.fold_via and scan_via

### DIFF
--- a/docs/scan.md
+++ b/docs/scan.md
@@ -458,7 +458,9 @@ We also provide a way to create a sequence of layers that can be applied to a se
 same interface as [haliax.nn.Stacked][], but with a different implementation. This is the [haliax.nn.BlockSeq][] module.
 BlockSeq implements those for loops directly, rather than using [haliax.fold][] or [haliax.scan][].
 
-[haliax.nn.scan.BlockFoldable][] is an interface that both [haliax.nn.Stacked][] and [haliax.nn.BlockSeq][] implement.
+[haliax.nn.scan.BlockFoldable][] is an interface that both [haliax.nn.Stacked][] and [haliax.nn.BlockSeq][] implement. It
+exposes the usual ``fold`` and ``scan`` methods as well as helpers ``fold_via`` and ``scan_via`` which return
+callables that perform the respective operations using a custom block function.
 
 ## API
 

--- a/src/haliax/nn/scan.py
+++ b/src/haliax/nn/scan.py
@@ -43,12 +43,13 @@ class ModuleInit(Protocol[M_co]):
 
 
 class BlockFoldable(Protocol[M]):
-    """
-    A superclass for [haliax.nn.Stacked][] and [haliax.nn.BlockSeq][] that exposes the fold and scan methods, as
-    well as a few other methods that are useful for these modules.
+    """Common interface for :class:`~haliax.nn.Stacked` and :class:`~haliax.nn.BlockSeq`.
 
-    This is a protocol, so you can use it as a type hint for a function that takes a Stacked or BlockSeq.
-    Equinox modules can't directly inherit from Protocols, but you can use it as a type hint.
+    The interface exposes the :py:meth:`fold` and :py:meth:`scan` methods along with the helper
+    methods :py:meth:`fold_via` and :py:meth:`scan_via`.
+
+    This is a protocol, so you can use it as a type hint for a function that takes a ``Stacked`` or ``BlockSeq``.
+    Equinox modules can't directly inherit from ``Protocol`` classes, but you can use it as a type hint.
     """
 
     Block: Axis
@@ -68,6 +69,28 @@ class BlockFoldable(Protocol[M]):
         ...
 
     def fold(self, init: T, *args, **kwargs) -> T:
+        ...
+
+    @overload
+    def fold_via(self, fn: FoldFunction[M, CarryT]) -> Callable[[CarryT], CarryT]:
+        ...
+
+    @overload
+    def fold_via(self, fn: Callable[[M, CarryT], CarryT]) -> Callable[[CarryT], CarryT]:
+        ...
+
+    def fold_via(self, fn: Callable[..., CarryT]) -> Callable[[CarryT], CarryT]:
+        ...
+
+    @overload
+    def scan_via(self, fn: ScanFunction[M, CarryT, OutputT_co]) -> Callable[[CarryT], tuple[CarryT, OutputT_co]]:
+        ...
+
+    @overload
+    def scan_via(self, fn: Callable[[M, CarryT], tuple[CarryT, OutputT_co]]) -> Callable[[CarryT], tuple[CarryT, OutputT_co]]:
+        ...
+
+    def scan_via(self, fn: Callable[..., tuple[CarryT, OutputT_co]]) -> Callable[[CarryT], tuple[CarryT, OutputT_co]]:
         ...
 
     def unstacked(self) -> Sequence[M]:
@@ -176,6 +199,59 @@ class BlockSeq(ModuleWithStateDictSerialization, Generic[M]):
             return carry
 
         return do_fold(init, *args, **kwargs)
+
+    @overload
+    def fold_via(self, fn: FoldFunction[M, CarryT]) -> Callable[[CarryT], CarryT]:
+        ...
+
+    @overload
+    def fold_via(self, fn: Callable[[M, CarryT], CarryT]) -> Callable[[CarryT], CarryT]:
+        ...
+
+    def fold_via(self, fn: Callable[..., CarryT]):
+        """Return a function that folds over the sequence using ``fn``.
+
+        ``fn`` should take a block and a carry and return a new carry. The
+        returned function mirrors :func:`haliax.fold` over the block axis.
+        """
+
+        def do_fold(init: CarryT) -> CarryT:
+            carry = init
+            for block in self.blocks:
+                carry = fn(block, carry)
+                carry = tree_checkpoint_name(carry, self._carry_ckpt_name)
+            return carry
+
+        return do_fold
+
+    @overload
+    def scan_via(self, fn: ScanFunction[M, CarryT, OutputT_co]) -> Callable[[CarryT], tuple[CarryT, OutputT_co]]:
+        ...
+
+    @overload
+    def scan_via(self, fn: Callable[[M, CarryT], tuple[CarryT, OutputT_co]]) -> Callable[[CarryT], tuple[CarryT, OutputT_co]]:
+        ...
+
+    def scan_via(self, fn: Callable[..., tuple[CarryT, OutputT_co]]):
+        """Return a function that scans over the sequence using ``fn``.
+
+        ``fn`` should take a block and a carry and return ``(carry, output)``.
+        Semantics match :func:`haliax.scan` over the block axis.
+        """
+
+        def do_scan(init: CarryT) -> tuple[CarryT, OutputT_co]:
+            out = []
+            carry = init
+            for block in self.blocks:
+                carry, extra = fn(block, carry)
+                carry = tree_checkpoint_name(carry, self._carry_ckpt_name)
+                extra = tree_checkpoint_name(extra, self._output_ckpt_name)
+                out.append(extra)
+
+            stacked_out = haliax.tree_util.tree_map(lambda *x: haliax.stack(self.Block, x), *out)
+            return carry, stacked_out
+
+        return do_scan
 
     def unstacked(self) -> Sequence[M]:
         return self.blocks


### PR DESCRIPTION
## Summary
- extend `BlockFoldable` protocol with `fold_via` and `scan_via`
- implement `fold_via` and `scan_via` for `BlockSeq`
- document the helpers in `docs/scan.md`

## Testing
- `uv run pre-commit run --all-files`
- `XLA_FLAGS=--xla_force_host_platform_device_count=8 PYTHONPATH=tests:src:. uv run pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_686e1155d01c8331a46a6af70e1fee99