### PR TITLE
Add named array pad function

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -258,6 +258,7 @@ These are all more or less directly from JAX's NumPy API.
 
 ::: haliax.clip
 ::: haliax.isclose
+::: haliax.pad
 ::: haliax.top_k
 ::: haliax.trace
 ::: haliax.tril

--- a/src/haliax/__init__.py
+++ b/src/haliax/__init__.py
@@ -66,7 +66,7 @@ from .core import (
 from .haxtyping import Named
 from .hof import fold, map, scan, vmap
 from .jax_utils import tree_checkpoint_name
-from .ops import clip, isclose, pad_left, trace, tril, triu, where
+from .ops import clip, isclose, pad_left, pad, trace, tril, triu, where
 from .partitioning import auto_sharded, axis_mapping, fsdp, named_jit, shard, shard_with_axis_mapping
 from .specialized_fns import top_k
 from .types import Scalar
@@ -1082,6 +1082,7 @@ __all__ = [
     "are_shape_checks_enabled",
     "isclose",
     "pad_left",
+    "pad",
     "stack",
     "concatenate",
     "eliminate_axes",

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -237,3 +237,16 @@ def test_reductions_produce_scalar_named_arrays_when_None_axis():
     # But if we specify axes, we always get a NamedArray, even if it's a scalar
     assert isinstance(hax.mean(named1, axis=("Height", "Width")), NamedArray)
     assert hax.mean(named1, axis=("Height", "Width")).axes == ()
+
+
+def test_pad():
+    Height = Axis("Height", 3)
+    Width = Axis("Width", 2)
+
+    arr = hax.arange((Height, Width))
+    padded = hax.pad(arr, {Height: (1, 2), Width: (0, 1)}, mode="constant", constant_values=0)
+
+    expected = jnp.pad(arr.array, [(1, 2), (0, 1)], mode="constant", constant_values=0)
+    assert padded.axes[0].size == Height.size + 3
+    assert padded.axes[1].size == Width.size + 1
+    assert jnp.all(expected == padded.array)


### PR DESCRIPTION
## Summary
- implement `pad` for NamedArrays
- expose `pad` in __init__ and docs
- test new `pad` helper

## Testing
- `pre-commit run --files docs/api.md src/haliax/ops.py src/haliax/__init__.py tests/test_ops.py`
- `pytest tests/test_ops.py::test_pad -q`

------
https://chatgpt.com/codex/tasks/task_e_687057008e8483318d052e63bb68f560