### PR TITLE
Update dslice indexing semantics

### DIFF
--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -147,6 +147,11 @@ def f(x, slice_size: int):
 f(q, 2)
 ```
 
+When indexing with ``dslice`` the slice is gathered starting at ``start`` for
+``size`` elements.  Reads beyond the end of the array return the ``fill_value``
+(0 by default).  When used with ``at`` updates, any writes outside the bounds of
+the array are dropped.  These semantics match JAX's scatter/gather behavior.
+
 For convenience/brevity, `dslice` is aliased as `ds`. In addition, we also expose `dblock`, which is a convenience
 function for computing the start and size of a slice given a block index and the size of the slice. Thus, the above
 example can be written as follows:

--- a/src/haliax/axis.py
+++ b/src/haliax/axis.py
@@ -598,14 +598,19 @@ def resolve_axis(axis_spec: AxisSpec, axis_selection: AxisSelection) -> AxisSpec
 
 
 class dslice(eqx.Module):
-    """
-    Dynamic slice, comprising a (start, length) pair. Also aliased as ds.
+    """Dynamic slice, comprising a (start, length) pair. Also aliased as ``ds``.
 
-    Normal numpy-isms like a[i:i+16] don't work in Jax inside jit, because slice doesn't like tracers and JAX
-    can't see that the slice is constant. This is a workaround that lets you do a[dslice(i, 16)] or even a[ds(i, 16)]
-    instead.
+    NumPy-style slices like ``a[i:i+16]`` don't work inside :func:`jax.jit`, because
+    JAX requires slice bounds to be static. ``dslice`` works around this by
+    separating the dynamic ``start`` from the static ``size`` so that you can
+    write ``a[dslice(i, 16)]`` or simply ``a[ds(i, 16)]``.
 
-    This class's name is taken from [jax.experimental.pallas.dslice][].
+    When used in indexing or ``at`` updates, ``dslice`` behaves like a gather of
+    ``size`` elements starting at ``start``. Reads beyond the end of the array are
+    filled with a value (0 by default) and writes outside the array bounds are
+    dropped, matching JAX's default scatter/gather semantics.
+
+    This class's name is taken from :mod:`jax.experimental.pallas`.
     """
 
     start: int


### PR DESCRIPTION
## Summary
- implement dslice indexing using arange indices
- remove `_handle_dynamic_slices`
- adjust index logic to gather with fill semantics
- simplify `_raw_indices_for_at`
- update dslice slice tests and add out-of-bounds read/write checks
- document dslice semantics in docs

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68731a0b0a648331b658ef295cbb2dcf