### PR TITLE
Improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 <a href="">
 <img alt="License" src="https://img.shields.io/github/license/stanford-crfm/haliax?color=blue" />
 </a>
-<a href="https://https://pypi.org/project/haliax/">
+<a href="https://pypi.org/project/haliax/">
     <img alt="PyPI" src="https://img.shields.io/pypi/v/haliax?color=blue" />
 </a>
 
 > *Though you don’t seem to be much for listening, it’s best to be careful. If you managed to catch hold of even just a piece of my name, you’d have all manner of power over me.*<br/>
 > — Patrick Rothfuss, *The Name of the Wind*
 
-Haliax is a [JAX](https:://github.com/google/jax) library for building neural networks with named tensors, in the tradition of Alexander Rush's [Tensor Considered Harmful](https://nlp.seas.harvard.edu/NamedTensor).
+Haliax is a [JAX](https://github.com/google/jax) library for building neural networks with named tensors, in the tradition of Alexander Rush's [Tensor Considered Harmful](https://nlp.seas.harvard.edu/NamedTensor).
 Named tensors improve the **legibility** and **compositionality** of tensor programs by using named axes instead of positional indices
 as typically used in NumPy, PyTorch, etc.
 

--- a/docs/indexing.md
+++ b/docs/indexing.md
@@ -1,7 +1,7 @@
 # Indexing and Slicing
 
 Haliax supports Numpy-style indexing, including so-called [Advanced Indexing](https://numpy.org/doc/stable/user/basics.indexing.html#advanced-indexing),
-though the syntax is necessarily different. Most forms of indexing are supporting, except we don't support indexing with
+though the syntax is necessarily different. Most forms of indexing are supported, except we don't support indexing with
 booleans right now. (JAX doesn't support indexing with non-constant bool arrays anyway,
 so I don't think it's worth the effort to implement it in Haliax.)
 

--- a/docs/nn.md
+++ b/docs/nn.md
@@ -6,7 +6,7 @@
 Haliax provides a small number of neural network modules that are compatible with Equinox, though
 they naturally all use [haliax.NamedArray][]. (We welcome PRs for more modules! Nothing too exotic though.)
 
-The most interesting of these modules is [haliax.nn.Stacked][], which allows you to create homogenous "stacks"
+The most interesting of these modules is [haliax.nn.Stacked][], which allows you to create homogeneous "stacks"
 of the same module (e.g. transformer blocks), which is a common pattern in deep learning.
 
 ### Linear

--- a/docs/state-dict.md
+++ b/docs/state-dict.md
@@ -226,7 +226,7 @@ any Axis members to match the new shape.
 ::: haliax.state_dict.save_state_dict
 ::: haliax.state_dict.load_state_dict
 
-### Converting betweewn State Dicts and Modules
+### Converting between State Dicts and Modules
 
 ::: haliax.state_dict.from_state_dict
 ::: haliax.state_dict.to_state_dict

--- a/docs/typing.md
+++ b/docs/typing.md
@@ -1,4 +1,4 @@
-from haliax import NamedArrayfrom haliax import NamedArray
+from haliax import NamedArray
 
 # NamedArray Type Annotations
 

--- a/src/haliax/nn/conv.py
+++ b/src/haliax/nn/conv.py
@@ -213,7 +213,7 @@ class Conv(_ConvBase):
         return x
 
     def _do_conv(self, inputs):
-        # _do_conv expects there ot be a single __batch__ dimension
+        # _do_conv expects there to be a single __batch__ dimension
         output_axes = _compute_output_axes(inputs, "__batch__", self.In, self.Out)
 
         batch_index = _index_of_name(inputs.axes, "__batch__")

--- a/src/haliax/nn/linear.py
+++ b/src/haliax/nn/linear.py
@@ -143,7 +143,7 @@ class MoELinear(eqx.Module):
     Experts: AxisSpec = eqx.field(static=True)
     In: Axis = eqx.field(static=True)
     Out: Axis = eqx.field(static=True)
-    # TODO: support quanitization for ragged_dot?
+    # TODO: support quantization for ragged_dot?
     # dot_general: DotGeneralOp = eqx.field(default_factory=DotGeneralOp.default)
 
     use_gmm: bool = eqx.field(static=True)

--- a/tests/test_rearrange.py
+++ b/tests/test_rearrange.py
@@ -293,7 +293,7 @@ def test_examples():
     r = einops_rearrange(z, "{B (H: h1 h) (W: w1 w) C} -> (B: B h1 w1) ... (C: C h w) ", h1=2, w1=2)
     assert r.axes == (Axis("B", B.size * 2 * 2), D, Axis("C", C.size * sH.size * sW.size))
     # unet attention reordering:
-    # postional: (qkv heads c) h w -> qkv heads c (h w)
+    # positional: (qkv heads c) h w -> qkv heads c (h w)
     # named: { (embed: qkv heads c) h w } -> qkv heads c (pos: h w)
     Embed = Axis("embed", 3 * 4 * C.size)
     attn = hax.random.randint(PRNGKey(0), (Embed, H, W), 0, 255)


### PR DESCRIPTION
## Summary
- fix a typo in the modules guide
- fix typos in Conv and Linear comments and rearrange test

## Testing
- `uv run pre-commit run --files docs/nn.md src/haliax/nn/conv.py src/haliax/nn/linear.py tests/test_rearrange.py`


------
https://chatgpt.com/codex/tasks/task_e_687335271c7c833191e94180f60be095