### PR TITLE
Add named wrappers for jnp.unique variants

### DIFF
--- a/src/haliax/__init__.py
+++ b/src/haliax/__init__.py
@@ -66,7 +66,21 @@ from .core import (
 from .haxtyping import Named
 from .hof import fold, map, scan, vmap
 from .jax_utils import tree_checkpoint_name
-from .ops import clip, isclose, pad_left, pad, trace, tril, triu, unique, where
+from .ops import (
+    clip,
+    isclose,
+    pad_left,
+    pad,
+    trace,
+    tril,
+    triu,
+    unique,
+    unique_values,
+    unique_counts,
+    unique_inverse,
+    unique_all,
+    where,
+)
 from .partitioning import auto_sharded, axis_mapping, fsdp, named_jit, shard, shard_with_axis_mapping
 from .specialized_fns import top_k
 from .types import Scalar
@@ -1035,6 +1049,10 @@ __all__ = [
     "trace",
     "where",
     "unique",
+    "unique_values",
+    "unique_counts",
+    "unique_inverse",
+    "unique_all",
     "clip",
     "tril",
     "triu",

--- a/src/haliax/ops.py
+++ b/src/haliax/ops.py
@@ -342,4 +342,106 @@ def unique(
     return tuple(ret)
 
 
-__all__ = ["trace", "where", "tril", "triu", "isclose", "pad_left", "pad", "clip", "unique"]
+def unique_values(
+    array: NamedArray,
+    Unique: Axis,
+    *,
+    axis: AxisSelector | None = None,
+    fill_value: ArrayLike | None = None,
+) -> NamedArray:
+    """Shortcut for :func:`unique` that returns only unique values."""
+
+    return typing.cast(
+        NamedArray,
+        unique(
+            array,
+            Unique,
+            axis=axis,
+            fill_value=fill_value,
+        ),
+    )
+
+
+def unique_counts(
+    array: NamedArray,
+    Unique: Axis,
+    *,
+    axis: AxisSelector | None = None,
+    fill_value: ArrayLike | None = None,
+) -> tuple[NamedArray, NamedArray]:
+    """Shortcut for :func:`unique` that also returns counts."""
+
+    values, counts = typing.cast(
+        tuple[NamedArray, NamedArray],
+        unique(
+            array,
+            Unique,
+            return_counts=True,
+            axis=axis,
+            fill_value=fill_value,
+        ),
+    )
+    return values, counts
+
+
+def unique_inverse(
+    array: NamedArray,
+    Unique: Axis,
+    *,
+    axis: AxisSelector | None = None,
+    fill_value: ArrayLike | None = None,
+) -> tuple[NamedArray, NamedArray]:
+    """Shortcut for :func:`unique` that also returns inverse indices."""
+
+    values, inverse = typing.cast(
+        tuple[NamedArray, NamedArray],
+        unique(
+            array,
+            Unique,
+            return_inverse=True,
+            axis=axis,
+            fill_value=fill_value,
+        ),
+    )
+    return values, inverse
+
+
+def unique_all(
+    array: NamedArray,
+    Unique: Axis,
+    *,
+    axis: AxisSelector | None = None,
+    fill_value: ArrayLike | None = None,
+) -> tuple[NamedArray, NamedArray, NamedArray, NamedArray]:
+    """Shortcut for :func:`unique` returning values, indices, inverse, and counts."""
+
+    values, indices, inverse, counts = typing.cast(
+        tuple[NamedArray, NamedArray, NamedArray, NamedArray],
+        unique(
+            array,
+            Unique,
+            return_index=True,
+            return_inverse=True,
+            return_counts=True,
+            axis=axis,
+            fill_value=fill_value,
+        ),
+    )
+    return values, indices, inverse, counts
+
+
+__all__ = [
+    "trace",
+    "where",
+    "tril",
+    "triu",
+    "isclose",
+    "pad_left",
+    "pad",
+    "clip",
+    "unique",
+    "unique_values",
+    "unique_counts",
+    "unique_inverse",
+    "unique_all",
+]


### PR DESCRIPTION
## Summary
- add `unique_values`, `unique_counts`, `unique_inverse`, and `unique_all` to ops
- export new helpers in `__init__`
- test the new wrappers

## Testing
- `uv run pre-commit run --files src/haliax/ops.py src/haliax/__init__.py tests/test_ops.py`
- `XLA_FLAGS=--xla_force_host_platform_device_count=8 PYTHONPATH=tests:src:. uv run pytest tests/test_ops.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687608bcac608331a9f8dc8b3aa51184