### PR TITLE
Add generic axis resolution in check_axes

### DIFF
--- a/docs/typing.md
+++ b/docs/typing.md
@@ -1,4 +1,4 @@
-from haliax import NamedArrayfrom haliax import NamedArray
+from haliax import NamedArray
 
 # NamedArray Type Annotations
 
@@ -27,9 +27,9 @@ if not arr.matches_axes(Float[NamedArray, "batch embed ..."]):
 ## DType-aware annotations
 
 Sometimes it is useful to express both the axes **and** the dtype in the type
-annotation.  The :mod:`haliax.typing` module defines symbolic types for all of
+annotation.  The :mod:`haliax.haxtyping` module defines symbolic types for all of
 JAX's common dtypes that can be indexed just like ``Named``.  In documentation
-examples we'll use ``import haliax.typing as ht``:
+examples we'll use ``import haliax.haxtyping as ht``:
 
 ```python
 import haliax.haxtyping as ht
@@ -98,3 +98,25 @@ Then suppress F722 in your linter to suppress that error.
 
 See the [jaxtyping documentation](https://docs.kidger.site/jaxtyping/faq/#flake8-or-ruff-are-throwing-an-error) for more
 details on the workaround.
+
+## Generic axes
+
+Sometimes the exact name of an axis is not known ahead of time but you want to
+enforce that multiple arguments share the same axis. Capitalized names in a type
+annotation act as generic axes that will be resolved at runtime:
+
+```python
+import haliax as hax
+import haliax.haxtyping as ht
+
+def foo(a: ht.f32[{"B", "embed"}], x: ht.i32[{"pos", "B"}]):
+    resolved = hax.check_axes(a=a, x=x)
+    assert resolved["B"] == hax.Axis("batch", 12)
+
+a = hax.zeros({"batch": 12, "embed": 4})
+x = hax.zeros({"pos": 4, "batch": 12}, dtype=jnp.int32)
+foo(a, x)
+```
+
+`check_axes` jointly resolves all generic axes and raises if they cannot be
+matched to the same underlying axis name and size across arguments.

--- a/src/haliax/__init__.py
+++ b/src/haliax/__init__.py
@@ -63,7 +63,7 @@ from .core import (
     unflatten_axis,
     updated_slice,
 )
-from .haxtyping import Named
+from .haxtyping import Named, check_axes
 from .hof import fold, map, scan, vmap
 from .jax_utils import tree_checkpoint_name
 from .ops import clip, isclose, pad_left, trace, tril, triu, where
@@ -1103,6 +1103,7 @@ __all__ = [
     "unflatten_axis",
     "ReductionFunction",
     "SimpleReductionFunction",
+    "check_axes",
     "NamedArrayAxes",
     "NamedArrayAxesSpec",
     "Named",

--- a/tests/test_check_axes.py
+++ b/tests/test_check_axes.py
@@ -1,0 +1,29 @@
+import jax.numpy as jnp
+
+import haliax as hax
+import haliax.haxtyping as ht
+
+
+def foo(a: ht.f32[{"B", "embed"}], x: ht.i32[{"pos", "B"}]):
+    resolved = hax.check_axes(a=a, x=x)
+    return resolved
+
+
+def test_generic_axis_resolution():
+    res = foo(
+        hax.zeros({"batch": 12, "embed": 4}),
+        hax.zeros({"pos": 4, "batch": 12}, dtype=jnp.int32),
+    )
+    assert res["B"] == hax.Axis("batch", 12)
+
+
+def test_generic_axis_mismatch():
+    try:
+        foo(
+            hax.zeros({"batch": 12, "embed": 4}),
+            hax.zeros({"pos": 4, "time": 12}, dtype=jnp.int32),
+        )
+    except ValueError:
+        pass
+    else:
+        assert False


### PR DESCRIPTION
## Summary
- implement `check_axes` for resolving capitalized generic axes (moved into `haxtyping`)
- export new helper and document usage
- test resolving and mismatch of generic axes

## Testing
- `pre-commit run --files docs/typing.md src/haliax/haxtyping.py src/haliax/__init__.py tests/test_check_axes.py`
- `pytest tests/test_check_axes.py`

------
https://chatgpt.com/codex/tasks/task_e_686e99212f988331bec0944b7c385a71