### PR TITLE
Add playbook for wrapping JAX functions

### DIFF
--- a/.playbooks/wrap-non-named.md
+++ b/.playbooks/wrap-non-named.md
@@ -1,0 +1,49 @@
+# Wrapping Functions with NamedArray Support
+
+This playbook explains how to convert a regular JAX function that works on unnamed arrays into a Haliax function that accepts `NamedArray` inputs and returns `NamedArray` outputs.
+
+## When is wrapping needed?
+Many JAX primitives only operate on regular arrays. To integrate them in Haliax you should provide a thin wrapper that handles axis metadata. Simple elementwise operations and reductions have helper utilities.
+
+## Elemwise Unary
+For a unary function that acts elementwise (e.g. `jnp.abs`):
+
+```python
+from haliax import wrap_elemwise_unary
+
+def abs(a):
+    return wrap_elemwise_unary(jnp.abs, a)
+```
+
+This preserves axis order and dtype.
+
+## Elemwise Binary
+For binary operations (e.g. `jnp.add`), decorate a function with `wrap_elemwise_binary`:
+
+```python
+from haliax import wrap_elemwise_binary
+
+@wrap_elemwise_binary
+def add(x1, x2):
+    return jnp.add(x1, x2)
+```
+
+Broadcasting between `NamedArray`s is handled automatically.
+
+## Reductions
+Reductions require choosing axes to eliminate. Use `wrap_reduction_call`:
+
+```python
+from haliax import wrap_reduction_call
+
+def sum(a, axis=None):
+    return wrap_reduction_call(jnp.sum, a, axis)
+```
+
+`axis` can be an `AxisSelector` or tuple. The wrapper returns a `NamedArray` with those axes removed.
+
+## Harder Cases
+Some functions need bespoke handling. For example `jnp.unique` returns several arrays and may change shape unpredictably. There is no generic helper, so you will need to manually map between `NamedArray` axes and the outputs. Use the lower level utilities in `haliax.wrap` for broadcasting and axis lookup.
+
+## Testing
+Add tests to ensure that named and unnamed calls produce the same results and that axis names are preserved or removed correctly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ repository. Follow these notes when implementing new features or fixing bugs.
 ## Playbook
 
 - Adding Haliax-style tensor typing annotations are described in @.playbooks/add-types.md
+- Wrapping standard JAX functions so they operate on `NamedArray` is explained in @.playbooks/wrap-non-named.md
 
 ## Code Style
 


### PR DESCRIPTION
## Summary
- add playbook for wrapping non-named JAX functions so they operate on `NamedArray`
- link new playbook from AGENTS.md

## Testing
- `pre-commit run --files AGENTS.md .playbooks/wrap-non-named.md`
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_68767603a3808331b350edf4a3ef5a1b