### PR TITLE
Add sharding visualization helper

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -9,3 +9,9 @@ Currently, we diagnose:
 
 * Reuse of arrays or NamedArrays in a field. [Equinox modules must be trees.](https://docs.kidger.site/equinox/faq/#a-module-saved-in-two-places-has-become-two-independent-copies)
 * Use of arrays or NamedArrays in a static field. Static data in JAX/Equinox must be hashable, and arrays are not hashable.
+
+## Tip 2: `hax.debug.visualize_shardings`
+
+Use `hax.debug.visualize_shardings` to quickly inspect how a PyTree is sharded.
+It prints the sharding of each array leaf, including the mapping from named axes
+to physical axes for :class:`haliax.NamedArray` leaves.

--- a/tests/test_visualize_sharding.py
+++ b/tests/test_visualize_sharding.py
@@ -1,0 +1,67 @@
+import numpy as np
+import jax
+import jax.numpy as jnp
+
+import haliax as hax
+from haliax import Axis
+from haliax.partitioning import ResourceAxis, axis_mapping, named_jit
+from test_utils import skip_if_not_enough_devices
+from haliax.debug import visualize_shardings
+
+Dim1 = Axis("dim1", 8)
+Dim2 = Axis("dim2", 8)
+Dim3 = Axis("dim3", 2)
+
+resource_map = {
+    "dim1": ResourceAxis.DATA,
+    "dim2": ResourceAxis.MODEL,
+    "dim3": ResourceAxis.REPLICA,
+}
+
+
+def test_visualize_shardings_runs(capsys):
+    mesh = jax.sharding.Mesh(
+        np.array(jax.devices()).reshape(-1, 1, 1),
+        (ResourceAxis.DATA, ResourceAxis.MODEL, ResourceAxis.REPLICA),
+    )
+    with axis_mapping(resource_map), mesh:
+        arr = hax.ones((Dim1, Dim2, Dim3))
+        visualize_shardings(arr)
+
+    out = capsys.readouterr().out
+    assert "dim1" in out and "dim2" in out and "dim3" in out
+
+
+def test_visualize_shardings_inside_jit(capsys):
+    mesh = jax.sharding.Mesh(np.array(jax.devices()).reshape(-1, 1), (ResourceAxis.DATA, ResourceAxis.MODEL))
+
+    @named_jit(out_axis_resources={"dim1": ResourceAxis.DATA})
+    def fn(x):
+        visualize_shardings(x)
+        return x
+
+    with axis_mapping({"dim1": ResourceAxis.DATA}), mesh:
+        x = hax.ones(Dim1)
+        fn(x)
+
+    out = capsys.readouterr().out
+    assert "dim1" in out
+
+
+def test_visualize_shardings_plain_array(capsys):
+    x = jnp.ones((4, 4))
+    visualize_shardings(x)
+    out = capsys.readouterr().out
+    assert out.strip() != ""
+
+
+@skip_if_not_enough_devices(2)
+def test_visualize_shardings_model_axis(capsys):
+    devices = jax.devices()
+    mesh = jax.sharding.Mesh(np.array(devices).reshape(-1, 2), (ResourceAxis.DATA, ResourceAxis.MODEL))
+    with axis_mapping({"dim1": ResourceAxis.DATA, "dim2": ResourceAxis.MODEL}), mesh:
+        arr = hax.ones((Dim1, Dim2))
+        visualize_shardings(arr)
+
+    out = capsys.readouterr().out
+    assert "dim2" in out


### PR DESCRIPTION
## Summary
- add utilities for named sharding visualization
- support plain JAX arrays in `visualize_shardings`
- document and test sharding visualization including model axis case

## Testing
- `uv run pre-commit run --all-files`
- `XLA_FLAGS=--xla_force_host_platform_device_count=8 PYTHONPATH=tests:src:. uv run pytest tests/test_visualize_sharding.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6879720915dc83318adb14a3b15137a4