### PR TITLE
Document haliax.vmap usage

### DIFF
--- a/docs/vmap.md
+++ b/docs/vmap.md
@@ -1,9 +1,38 @@
-## Vectorization
+## Vectorization with `haliax.vmap`
 
+`haliax.vmap` is a [`NamedArray`][haliax.NamedArray] aware wrapper around
+[`jax.vmap`][jax.vmap].  Instead of supplying positional axis numbers you pass
+the [`Axis`][haliax.Axis] (or axis name) you want to map over.  Any
+`NamedArray` containing that axis is mapped in parallel and the axis is
+reinserted in the output.  Regular JAX arrays can be mapped as well by
+providing a `default` spec or per‑argument overrides.
 
-This primitive is also used by [`Stacked.vmap`](scan.md#apply-blocks-in-parallel-with-vmap)
-to apply an entire stack of blocks in parallel.
+Unlike vanilla `jax.vmap`, you may supply **one or more axes**.  When multiple
+axes are given, the function is vmapped over each axis in turn (innermost first).
+If an axis isn't already present in the array you must also specify its size,
+either by passing an `Axis` object (`Axis("batch", 4)`) or a mapping such as
+`{"batch": 4}` so the new dimension can be inserted.
 
-(This is a work in progress. Please contact dlwh for more information.)
+### Basic Example
+
+```python
+import haliax as hax
+
+Batch = hax.Axis("batch", 4)
+
+def double(x):
+    return x * 2
+
+x = hax.arange(Batch)
+y = hax.vmap(double, Batch)(x)
+```
+
+The result `y` has the same `Batch` axis as `x`, and each element was processed
+in parallel.  With JAX you would write `jax.vmap(double)(x.array)` and manually
+specify `in_axes`, but Haliax handles the axis automatically.
+
+For applying many modules in parallel see
+[`Stacked.vmap`](scan.md#apply-blocks-in-parallel-with-vmap) which builds on this
+primitive.
 
 ::: haliax.vmap


### PR DESCRIPTION
## Summary
- document how `haliax.vmap` works and how it differs from `jax.vmap`
- show a simple code example in docs/vmap.md
- mention `Stacked.vmap` for advanced parallelism
- clarify that multiple axes can be provided and axis sizes are required when the axis isn't present

## Testing
- `uv run pre-commit run --files docs/vmap.md`
- `uv run pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6883b18fbc288331bbc46a490c555073