### PR TITLE
Implement shard_map wrapper

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -284,6 +284,7 @@ See also the section on [Partitioning](partitioning.md).
 ::: haliax.shard
 ::: haliax.named_jit
 ::: haliax.fsdp
+::: haliax.shard_map
 ::: haliax.partitioning.round_axis_for_partitioning
 ::: haliax.partitioning.physical_axis_name
 ::: haliax.partitioning.physical_axis_size

--- a/docs/partitioning.md
+++ b/docs/partitioning.md
@@ -125,6 +125,7 @@ This is an older function that is being deprecated in favor of `shard`. It is fu
 
 ::: haliax.named_jit
 ::: haliax.fsdp
+::: haliax.shard_map
 
 
 ### Querying the Mesh and Axis Mapping

--- a/src/haliax/__init__.py
+++ b/src/haliax/__init__.py
@@ -81,7 +81,7 @@ from .ops import (
     unique_all,
     where,
 )
-from .partitioning import auto_sharded, axis_mapping, fsdp, named_jit, shard, shard_with_axis_mapping
+from .partitioning import auto_sharded, axis_mapping, fsdp, named_jit, shard, shard_map, shard_with_axis_mapping
 from .specialized_fns import top_k
 from .types import Scalar
 from .util import is_named_array
@@ -1096,6 +1096,7 @@ __all__ = [
     "named_jit",
     "fsdp",
     "shard_with_axis_mapping",
+    "shard_map",
     "shard",
     "enable_shape_checks",
     "are_shape_checks_enabled",

--- a/src/haliax/nn/linear.py
+++ b/src/haliax/nn/linear.py
@@ -7,7 +7,7 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 from jax.experimental.pallas.ops.tpu.megablox import gmm
-from jax.experimental.shard_map import shard_map
+from ..partitioning import shard_map
 from jax.random import PRNGKey
 
 import haliax as hax

--- a/src/haliax/partitioning.py
+++ b/src/haliax/partitioning.py
@@ -658,7 +658,29 @@ def shard_map(
     check_rep: bool = False,
     **kwargs,
 ):
-    """A NamedArray-friendly wrapper around :func:`jax.experimental.shard_map.shard_map`."""
+    """A NamedArray-friendly wrapper around :func:`jax.experimental.shard_map.shard_map`.
+
+    Args:
+        f: The function to apply with ``shard_map``.
+        in_specs: PyTree describing the input sharding. Each leaf can be a
+            :class:`NamedArray`, :class:`Axis`, or a sequence of ``Axis`` objects,
+            or a :class:`PartitionSpec`. ``NamedArray`` and ``Axis`` leaves will be
+            converted to ``PartitionSpec`` using :func:`pspec_for_axis` and the
+            provided ``axis_mapping``.
+        out_specs: Like ``in_specs`` but for the output. If ``None`` the output
+            specifications are inferred by evaluating ``f`` on dummy inputs and
+            using the returned axis names.
+        mesh: The mesh to run the computation on. Defaults to the current mesh
+            returned by :func:`_get_mesh`.
+        axis_mapping: Optional mapping from logical axis names to mesh axis names
+            used when converting ``Axis`` objects to ``PartitionSpec``.
+        check_rep: Passed through to ``jax.shard_map``.
+        **kwargs: Additional arguments forwarded to ``jax.shard_map``.
+
+        Returns:
+            A wrapped function that accepts and returns ``NamedArray`` objects
+            according to the provided specifications.
+    """
 
     mesh = mesh or _get_mesh()
 

--- a/tests/test_shard_map.py
+++ b/tests/test_shard_map.py
@@ -1,0 +1,67 @@
+import numpy as np
+import jax
+import jax.numpy as jnp
+from jax.sharding import Mesh
+
+import haliax as hax
+from haliax import Axis
+from haliax.partitioning import ResourceAxis, axis_mapping
+from test_utils import skip_if_not_enough_devices
+
+Dim = Axis("dim", 8)
+
+@skip_if_not_enough_devices(2)
+def test_shard_map_basic():
+    mesh = Mesh(np.array(jax.devices()), (ResourceAxis.DATA,))
+
+    def fn(x):
+        return x + 1
+
+    sm = hax.shard_map(fn, in_specs=Dim, out_specs=Dim, mesh=mesh, check_rep=False)
+    x = hax.ones(Dim)
+    with axis_mapping({"dim": ResourceAxis.DATA}), mesh:
+        out = sm(x.array)
+    assert out.axes == (Dim,)
+    assert jnp.allclose(out.array, x.array + 1)
+
+
+@skip_if_not_enough_devices(2)
+def test_shard_map_infer_out():
+    mesh = Mesh(np.array(jax.devices()), (ResourceAxis.DATA,))
+
+    def fn(x):
+        return x + 2
+
+    sm = hax.shard_map(fn, in_specs=Dim, out_specs=None, mesh=mesh, check_rep=False)
+    x = hax.ones(Dim)
+    with axis_mapping({"dim": ResourceAxis.DATA}), mesh:
+        out = sm(x.array)
+    assert out.axes == (Dim,)
+    assert jnp.allclose(out.array, x.array + 2)
+
+
+@skip_if_not_enough_devices(2)
+def test_shard_map_pytree_multidim_output():
+    mesh = Mesh(np.array(jax.devices()), (ResourceAxis.DATA,))
+
+    B = Axis("b", 8)
+    C = Axis("c", 4)
+    D = Axis("d", 2)
+
+    def fn(x):
+        return {
+            "expanded": hax.broadcast_axis(x, D),
+            "twice": x + x,
+        }
+
+    x = hax.ones((B, C))
+    sm = hax.shard_map(fn, in_specs=x, out_specs=None, mesh=mesh, check_rep=False)
+    with axis_mapping({"b": ResourceAxis.DATA}), mesh:
+        out = sm(x.array)
+
+    assert isinstance(out, dict)
+    assert out["expanded"].axes == (D, B, C)
+    assert out["twice"].axes == (B, C)
+    expected_expanded = jnp.broadcast_to(x.array, (D.size, B.size, C.size))
+    assert jnp.allclose(out["expanded"].array, expected_expanded)
+    assert jnp.allclose(out["twice"].array, x.array * 2)


### PR DESCRIPTION
## Summary
- add `shard_map` wrapper to partitioning
- expose `shard_map` in the public API
- update Linear to use new wrapper
- add tests including multi‑output PyTree with multidimensional `NamedArray`

## Testing
- `pre-commit run --files src/haliax/partitioning.py tests/test_shard_map.py`
- `XLA_FLAGS=--xla_force_host_platform_device_count=8 PYTHONPATH=tests:src:. uv run pytest tests/test_shard_map.py`
- `XLA_FLAGS=--xla_force_host_platform_device_count=8 PYTHONPATH=tests:src:. uv run pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_688692d3072c83319e6eb8c9801434e5