### PR TITLE
Implement shard_map wrapper

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -284,6 +284,7 @@ See also the section on [Partitioning](partitioning.md).
 ::: haliax.shard
 ::: haliax.named_jit
 ::: haliax.fsdp
+::: haliax.shard_map
 ::: haliax.partitioning.round_axis_for_partitioning
 ::: haliax.partitioning.physical_axis_name
 ::: haliax.partitioning.physical_axis_size

--- a/docs/partitioning.md
+++ b/docs/partitioning.md
@@ -125,6 +125,7 @@ This is an older function that is being deprecated in favor of `shard`. It is fu
 
 ::: haliax.named_jit
 ::: haliax.fsdp
+::: haliax.shard_map
 
 
 ### Querying the Mesh and Axis Mapping

--- a/src/haliax/__init__.py
+++ b/src/haliax/__init__.py
@@ -81,7 +81,7 @@ from .ops import (
     unique_all,
     where,
 )
-from .partitioning import auto_sharded, axis_mapping, fsdp, named_jit, shard, shard_with_axis_mapping
+from .partitioning import auto_sharded, axis_mapping, fsdp, named_jit, shard, shard_map, shard_with_axis_mapping
 from .specialized_fns import top_k
 from .types import Scalar
 from .util import is_named_array
@@ -1096,6 +1096,7 @@ __all__ = [
     "named_jit",
     "fsdp",
     "shard_with_axis_mapping",
+    "shard_map",
     "shard",
     "enable_shape_checks",
     "are_shape_checks_enabled",

--- a/src/haliax/nn/linear.py
+++ b/src/haliax/nn/linear.py
@@ -7,7 +7,7 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 from jax.experimental.pallas.ops.tpu.megablox import gmm
-from jax.experimental.shard_map import shard_map
+from ..partitioning import shard_map
 from jax.random import PRNGKey
 
 import haliax as hax

--- a/src/haliax/partitioning.py
+++ b/src/haliax/partitioning.py
@@ -8,6 +8,9 @@ from typing import Callable, ContextManager, Mapping, Optional, ParamSpec, Seque
 
 import equinox as eqx
 import jax
+import jax.numpy as jnp
+import jax.tree_util as jtu
+from jax.experimental.shard_map import shard_map as jax_shard_map
 from equinox import is_array, module_update_wrapper
 from jax.lax import with_sharding_constraint
 from jax.sharding import (
@@ -33,7 +36,7 @@ from jaxtyping import PyTree
 import haliax.tree_util as htu
 from haliax._src.compile_utils import compile_cache
 
-from .axis import Axis, AxisSelection, AxisSelector, axis_spec_to_shape_dict
+from .axis import Axis, AxisSelection, AxisSelector, axis_spec_to_shape_dict, to_jax_shape
 from .core import NamedArray
 from .jax_utils import Static, is_in_jit, is_jax_array_like, is_on_mac_metal
 from .tree_util import hashable_combine, hashable_partition
@@ -645,6 +648,136 @@ def _get_mesh() -> Mesh | AbstractMesh:
     return thread_resources.env.physical_mesh
 
 
+def shard_map(
+    f: Callable,
+    *,
+    in_specs,
+    out_specs=None,
+    mesh: Optional[Mesh] = None,
+    axis_mapping: Optional[ResourceMapping] = None,
+    check_rep: bool = False,
+    **kwargs,
+):
+    """A NamedArray-friendly wrapper around :func:`jax.experimental.shard_map.shard_map`.
+
+    Args:
+        f: The function to apply with ``shard_map``.
+        in_specs: PyTree describing the input sharding. Each leaf can be a
+            :class:`NamedArray`, :class:`Axis`, or a sequence of ``Axis`` objects,
+            or a :class:`PartitionSpec`. ``NamedArray`` and ``Axis`` leaves will be
+            converted to ``PartitionSpec`` using :func:`pspec_for_axis` and the
+            provided ``axis_mapping``.
+        out_specs: Like ``in_specs`` but for the output. If ``None`` the output
+            specifications are inferred by evaluating ``f`` on dummy inputs and
+            using the returned axis names.
+        mesh: The mesh to run the computation on. Defaults to the current mesh
+            returned by :func:`_get_mesh`.
+        axis_mapping: Optional mapping from logical axis names to mesh axis names
+            used when converting ``Axis`` objects to ``PartitionSpec``.
+        check_rep: Passed through to ``jax.shard_map``.
+        **kwargs: Additional arguments forwarded to ``jax.shard_map``.
+
+        Returns:
+            A wrapped function that accepts and returns ``NamedArray`` objects
+            according to the provided specifications.
+    """
+
+    mesh = mesh or _get_mesh()
+
+    def _axes(spec):
+        if isinstance(spec, NamedArray):
+            return spec.axes
+        elif isinstance(spec, Axis):
+            return spec
+        elif isinstance(spec, Sequence) and all(isinstance(ax, Axis) for ax in spec):
+            return tuple(spec)
+        else:
+            return None
+
+    def _pspec(spec):
+        if isinstance(spec, (PartitionSpec, NamedSharding)) or spec is None:
+            return spec
+        axes = _axes(spec)
+        if axes is None:
+            return spec
+        return pspec_for_axis(axes, axis_mapping)
+
+    def _leaf(x):
+        return isinstance(x, NamedArray) or (
+            isinstance(x, Sequence) and all(isinstance(ax, Axis) for ax in x)
+        )
+
+    arg_axes = jtu.tree_map(_axes, in_specs, is_leaf=_leaf)
+    part_in_specs = jtu.tree_map(_pspec, in_specs, is_leaf=_leaf)
+
+    if out_specs is None:
+        def dummy(spec):
+            ax = _axes(spec)
+            if ax is None:
+                return spec
+            shape = to_jax_shape(ax)
+            arr = jnp.zeros(shape)
+            return NamedArray(arr, ax if isinstance(ax, tuple) else (ax,))
+
+        dummy_args = jtu.tree_map(dummy, in_specs, is_leaf=_leaf)
+
+        out_shape = _cached_filter_eval_shape(f, dummy_args)
+        out_axes = jtu.tree_map(_axes, out_shape, is_leaf=_leaf)
+        part_out_specs = jtu.tree_map(_pspec, out_shape, is_leaf=_leaf)
+    else:
+        out_axes = jtu.tree_map(_axes, out_specs, is_leaf=_leaf)
+        part_out_specs = jtu.tree_map(_pspec, out_specs, is_leaf=_leaf)
+
+    def inner(*arrays):
+        arr_flat, arr_tree = jtu.tree_flatten(arrays)
+        ax_flat, _ = jtu.tree_flatten(arg_axes, is_leaf=_leaf)
+
+        def wrap_arg(a, ax):
+            if ax is None:
+                return a
+            axes = ax if isinstance(ax, tuple) else (ax,)
+            return NamedArray(a, axes)
+
+        named_args_flat = [wrap_arg(a, ax) for a, ax in zip(arr_flat, ax_flat)]
+        named_args = jtu.tree_unflatten(arr_tree, named_args_flat)
+        result = f(*named_args)
+        return jtu.tree_map(
+            lambda r: r.array if isinstance(r, NamedArray) else r,
+            result,
+            is_leaf=lambda x: isinstance(x, NamedArray),
+        )
+
+    sm_fn = jax_shard_map(
+        inner,
+        mesh=mesh,
+        in_specs=part_in_specs,
+        out_specs=part_out_specs,
+        check_rep=check_rep,
+        **kwargs,
+    )
+
+    def wrapper(*args):
+        arrays = jtu.tree_map(
+            lambda a: a.array if isinstance(a, NamedArray) else a,
+            args,
+            is_leaf=lambda x: isinstance(x, NamedArray),
+        )
+        out = sm_fn(*arrays)
+        out_flat, out_tree = jtu.tree_flatten(out)
+        ax_out_flat, _ = jtu.tree_flatten(out_axes, is_leaf=_leaf)
+
+        def wrap_out(a, ax):
+            if ax is None:
+                return a
+            axes = ax if isinstance(ax, tuple) else (ax,)
+            return NamedArray(a, axes)
+
+        wrapped_out = [wrap_out(a, ax) for a, ax in zip(out_flat, ax_out_flat)]
+        return jtu.tree_unflatten(out_tree, wrapped_out)
+
+    return wrapper
+
+
 def _is_jit_tracer(x) -> bool:
     if isinstance(x, NamedArray):
         x = x.array
@@ -659,6 +792,7 @@ __all__ = [
     "auto_sharded",
     "shard",
     "shard_with_axis_mapping",
+    "shard_map",
     "infer_resource_partitions",
     "named_jit",
     "fsdp",

--- a/tests/test_shard_map.py
+++ b/tests/test_shard_map.py
@@ -1,0 +1,83 @@
+import numpy as np
+import jax
+import jax.numpy as jnp
+from jax.sharding import Mesh
+
+import haliax as hax
+from haliax import Axis
+from haliax.partitioning import ResourceAxis, axis_mapping
+from test_utils import skip_if_not_enough_devices
+
+Dim = Axis("dim", 8)
+
+@skip_if_not_enough_devices(2)
+def test_shard_map_basic():
+    mesh = Mesh(np.array(jax.devices()), (ResourceAxis.DATA,))
+
+    def fn(x):
+        return x + 1
+
+    sm = hax.shard_map(fn, in_specs=Dim, out_specs=Dim, mesh=mesh, check_rep=False)
+    x = hax.ones(Dim)
+    with axis_mapping({"dim": ResourceAxis.DATA}), mesh:
+        out = sm(x.array)
+    assert out.axes == (Dim,)
+    assert jnp.allclose(out.array, x.array + 1)
+
+
+@skip_if_not_enough_devices(2)
+def test_shard_map_infer_out():
+    mesh = Mesh(np.array(jax.devices()), (ResourceAxis.DATA,))
+
+    def fn(x):
+        return x + 2
+
+    sm = hax.shard_map(fn, in_specs=Dim, out_specs=None, mesh=mesh, check_rep=False)
+    x = hax.ones(Dim)
+    with axis_mapping({"dim": ResourceAxis.DATA}), mesh:
+        out = sm(x.array)
+    assert out.axes == (Dim,)
+    assert jnp.allclose(out.array, x.array + 2)
+
+
+@skip_if_not_enough_devices(2)
+def test_shard_map_infer_in_specs():
+    mesh = Mesh(np.array(jax.devices()), (ResourceAxis.DATA,))
+
+    def fn(x):
+        return x * 3
+
+    spec = hax.ones(Dim)
+    sm = hax.shard_map(fn, in_specs=spec, out_specs=Dim, mesh=mesh, check_rep=False)
+    x = hax.ones(Dim)
+    with axis_mapping({"dim": ResourceAxis.DATA}), mesh:
+        out = sm(x.array)
+    assert out.axes == (Dim,)
+    assert jnp.allclose(out.array, x.array * 3)
+
+
+@skip_if_not_enough_devices(2)
+def test_shard_map_pytree_multidim_output():
+    mesh = Mesh(np.array(jax.devices()), (ResourceAxis.DATA,))
+
+    B = Axis("b", 8)
+    C = Axis("c", 4)
+    D = Axis("d", 2)
+
+    def fn(x):
+        return {
+            "expanded": hax.broadcast_axis(x, D),
+            "twice": x + x,
+        }
+
+    x = hax.ones((B, C))
+    sm = hax.shard_map(fn, in_specs=x, out_specs=None, mesh=mesh, check_rep=False)
+    with axis_mapping({"b": ResourceAxis.DATA}), mesh:
+        out = sm(x.array)
+
+    assert isinstance(out, dict)
+    assert out["expanded"].axes == (D, B, C)
+    assert out["twice"].axes == (B, C)
+    expected_expanded = jnp.broadcast_to(x.array, (D.size, B.size, C.size))
+    assert jnp.allclose(out["expanded"].array, expected_expanded)
+    assert jnp.allclose(out["twice"].array, x.array * 2)


### PR DESCRIPTION
## Summary
- add `shard_map` wrapper to partitioning
- expose `shard_map` in the public API
- update Linear to use new wrapper
- add tests including multi-output PyTree with multidimensional `NamedArray`
- document `shard_map`
- add test for in_spec inference

## Testing
- `pre-commit run --files tests/test_shard_map.py src/haliax/partitioning.py docs/api.md docs/partitioning.md src/haliax/__init__.py src/haliax/nn/linear.py`
- `XLA_FLAGS=--xla_force_host_platform_device_count=8 PYTHONPATH=tests:src:. uv run pytest tests/test_shard_map.py -q`
- `XLA_FLAGS=--xla_force_host_platform_device_count=8 PYTHONPATH=tests:src:. uv run pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_688692d3072c83319e6eb8c9801434e5