### PR TITLE
Add support for scalar NamedArray shift in roll

### DIFF
--- a/src/haliax/core.py
+++ b/src/haliax/core.py
@@ -1361,13 +1361,26 @@ def unbind(array: NamedArray, axis: AxisSelector) -> List[NamedArray]:
     return [haliax.auto_sharded(NamedArray(a, new_axes)) for a in arrays]
 
 
-def roll(array: NamedArray, shift: Union[int, Tuple[int, ...]], axis: AxisSelection) -> NamedArray:
+def roll(
+    array: NamedArray,
+    shift: Union[IntScalar, Tuple[int, ...], "NamedArray"],
+    axis: AxisSelection,
+) -> NamedArray:
+    """Roll an array along an axis or axes.
+
+    ``shift`` may be a scalar ``NamedArray`` in addition to an ``int`` or tuple of
+    integers.
     """
-    Roll an array along an axis or axes. Analogous to np.roll
-    """
+
     axis_indices = array.axis_indices(axis)
     if axis_indices is None:
         raise ValueError(f"axis {axis} not found in {array}")
+
+    if isinstance(shift, NamedArray):
+        if shift.ndim != 0:
+            raise TypeError("shift must be a scalar NamedArray")
+        shift = shift.array
+
     return NamedArray(jnp.roll(array.array, shift, axis_indices), array.axes)
 
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -423,3 +423,17 @@ def test_bincount():
     out_w = hax.bincount(x, B, weights=w)
     expected_w = jnp.bincount(x.array, weights=w.array, length=B.size)
     assert jnp.allclose(out_w.array, expected_w)
+
+
+def test_roll_scalar_named_shift():
+    H = Axis("H", 4)
+    W = Axis("W", 3)
+
+    arr = hax.arange((H, W))
+    shift = hax.named(jnp.array(1), ())
+
+    rolled = hax.roll(arr, shift, H)
+    expected = jnp.roll(arr.array, shift.array, axis=0)
+
+    assert rolled.axes == arr.axes
+    assert jnp.all(rolled.array == expected)


### PR DESCRIPTION
## Summary
- allow `haliax.roll` to accept a scalar `NamedArray` as the shift
- test rolling with a scalar `NamedArray` shift

## Testing
- `uv run pre-commit run --all-files`
- `XLA_FLAGS=--xla_force_host_platform_device_count=8 PYTHONPATH=tests:src:. uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b18ba094083319078616c7d1b4fac