### PR TITLE
refactor infer_resource_partitions to use pspec_for

### DIFF
--- a/tests/test_partitioning.py
+++ b/tests/test_partitioning.py
@@ -7,7 +7,13 @@ from jaxtyping import Array
 
 import haliax as hax
 from haliax import Axis, NamedArray
-from haliax.partitioning import ResourceAxis, axis_mapping, infer_resource_partitions, named_jit
+from haliax.partitioning import (
+    ResourceAxis,
+    axis_mapping,
+    infer_resource_partitions,
+    named_jit,
+    pspec_for,
+)
 from test_utils import skip_if_not_enough_devices
 
 
@@ -38,6 +44,19 @@ def test_infer_named_axes():
 
         assert axes.named == NamedSharding(mesh, spec)
         assert axes.unnamed1.is_fully_replicated
+
+
+def test_pspec_for_named_axes():
+    mesh = Mesh(np.array(jax.devices()).reshape(-1, 1), (ResourceAxis.DATA, ResourceAxis.MODEL))
+    with axis_mapping(resource_map), mesh:
+        mod = MyModule(named=hax.ones((Dim1, Dim2, Dim3)), unnamed1=jnp.ones(Dim2.size), static_field=1)
+
+        specs: MyModule = pspec_for(mod, preserve_existing_shardings=False)
+
+        spec = PartitionSpec(None, ResourceAxis.DATA, ResourceAxis.MODEL)
+
+        assert specs.named == spec
+        assert specs.unnamed1 == PartitionSpec(None)
 
 
 class MyModuleInit(eqx.Module):


### PR DESCRIPTION
## Summary
- add `pspec_for` helper to compute PartitionSpecs
- refactor `infer_resource_partitions` to use `pspec_for`
- test `pspec_for` for named and unnamed arrays

## Testing
- `uv run pre-commit run --all-files`
- `XLA_FLAGS=--xla_force_host_platform_device_count=8 PYTHONPATH=tests:src:. uv run pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_689d701287a08331822a9ecce8da737d