### PR TITLE
Add field wrapper with axis names metadata

### DIFF
--- a/src/haliax/__init__.py
+++ b/src/haliax/__init__.py
@@ -17,6 +17,7 @@ import haliax.random as random
 import haliax.state_dict as state_dict
 import haliax.tree_util as tree_util
 import haliax.util as util
+from .field import field
 
 from ._src.dot import dot
 from ._src.einsum import einsum
@@ -932,6 +933,7 @@ __all__ = [
     "tree_util",
     "nn",
     "state_dict",
+    "field",
     "Axis",
     "AxisSpec",
     "AxisSelection",

--- a/src/haliax/field.py
+++ b/src/haliax/field.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import equinox as eqx
+
+
+def field(
+    *,
+    converter: Callable[[Any], Any] | None = None,
+    static: bool = False,
+    axis_names: tuple[str, ...] | None = None,
+    **kwargs,
+):
+    """Wrapper around :func:`equinox.field` with optional ``axis_names`` metadata.
+
+    Args:
+        converter: Optional function applied to the value during dataclass initialisation.
+        static: Whether the field is static in the PyTree.
+        axis_names: Optional axis names associated with array fields. Cannot be
+            specified together with ``static=True``.
+        **kwargs: Additional keyword arguments forwarded to :func:`dataclasses.field`.
+
+    Returns:
+        A dataclasses field configured like :func:`equinox.field` with additional
+        ``axis_names`` metadata.
+    """
+    if static and axis_names is not None:
+        raise ValueError("axis_names cannot be specified together with static=True")
+
+    metadata = dict(kwargs.pop("metadata", {}))
+    metadata["axis_names"] = axis_names
+
+    field_kwargs = {}
+    if converter is not None:
+        field_kwargs["converter"] = converter
+
+    return eqx.field(static=static, metadata=metadata, **field_kwargs, **kwargs)

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -1,0 +1,19 @@
+import jax.numpy as jnp
+import equinox as eqx
+import pytest
+
+import haliax as hax
+
+
+class M(eqx.Module):
+    a: jnp.ndarray = hax.field(axis_names=("batch",))
+
+
+def test_axis_names_metadata():
+    field = M.__dataclass_fields__["a"]
+    assert field.metadata["axis_names"] == ("batch",)
+
+
+def test_axis_names_static_exclusive():
+    with pytest.raises(ValueError):
+        hax.field(static=True, axis_names=("x",))


### PR DESCRIPTION
## Summary
- add `haliax.field` wrapper allowing `axis_names` metadata for array fields
- expose `field` in top-level package exports
- test `axis_names` metadata and exclusive behavior with `static`

## Testing
- `uv run pre-commit run --files src/haliax/field.py src/haliax/__init__.py tests/test_field.py`
- `XLA_FLAGS=--xla_force_host_platform_device_count=8 PYTHONPATH=tests:src:. uv run pytest tests/test_field.py`


------
https://chatgpt.com/codex/tasks/task_e_689d6eb329808331923e5dbd457c973b