### PR TITLE
Improve scan error when unnamed arrays mismatch axis

### DIFF
--- a/tests/test_hof.py
+++ b/tests/test_hof.py
@@ -147,9 +147,9 @@ def test_scan_reports_mismatched_unnamed_array():
     bad = jnp.zeros((Height.size - 1, 3))
 
     with pytest.raises(ValueError) as e:
-        hax.scan(f, Height)(0, good, bad)
+        hax.scan(f, Height)(0, good, y=bad)
 
-    assert "[0][1]" in str(e.value)
+    assert "y has leading dimension" in str(e.value)
 
 
 def test_scan_reports_eqx_module_field_path():
@@ -166,7 +166,7 @@ def test_scan_reports_eqx_module_field_path():
     with pytest.raises(ValueError) as e:
         hax.scan(f, Height)(0, foo)
 
-    assert "[0][0].my_array" in str(e.value)
+    assert "foo.my_array" in str(e.value)
 
 
 def test_fold():


### PR DESCRIPTION
## Summary
- detect leading axis mismatches for unnamed arrays in `scan`
- report tree path for mismatched leaves
- ensure eqx.Module field names appear in mismatch errors
- test mismatch detection in scan

## Testing
- `uv run pre-commit run --all-files`
- `XLA_FLAGS=--xla_force_host_platform_device_count=8 PYTHONPATH=tests:src:. uv run pytest tests/test_hof.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8c0e0370483319ecdf62ddbb96047