### PR TITLE
feat: add array comparison helpers

### DIFF
--- a/.agents/projects/api_parity.md
+++ b/.agents/projects/api_parity.md
@@ -4,15 +4,15 @@ This document tracks JAX NumPy functions not yet wrapped by Haliax.
 APIs that don't translate well to named tensors are intentionally omitted here. This includes dtype constructors, raw array converters (e.g. `from_dlpack`), indexing helpers like `c_`/`r_`, and functions whose JAX counterparts already work with `NamedArray` out of the box. Basic array construction is handled by `haliax.named`, so functions such as `array` or `asarray` are not listed.
 
 ## numpy
-- [ ] `allclose`
+- [x] `allclose`
 - [ ] `amin`
 - [ ] `append`
 - [ ] `apply_along_axis`
 - [ ] `apply_over_axes`
 - [ ] `argpartition`
 - [ ] `argwhere`
-- [ ] `array_equal`
-- [ ] `array_equiv`
+- [x] `array_equal`
+- [x] `array_equiv`
 - [ ] `array_split`
 - [ ] `astype`
 - [ ] `atan2`

--- a/docs/api.md
+++ b/docs/api.md
@@ -259,6 +259,9 @@ These are all more or less directly from JAX's NumPy API.
 ::: haliax.bincount
 ::: haliax.clip
 ::: haliax.isclose
+::: haliax.allclose
+::: haliax.array_equal
+::: haliax.array_equiv
 ::: haliax.pad
 ::: haliax.searchsorted
 ::: haliax.top_k

--- a/src/haliax/__init__.py
+++ b/src/haliax/__init__.py
@@ -69,6 +69,9 @@ from .hof import fold, map, scan, vmap
 from .jax_utils import tree_checkpoint_name
 from .ops import (
     clip,
+    allclose,
+    array_equal,
+    array_equiv,
     isclose,
     pad_left,
     pad,
@@ -1105,6 +1108,9 @@ __all__ = [
     "shard",
     "enable_shape_checks",
     "are_shape_checks_enabled",
+    "allclose",
+    "array_equal",
+    "array_equiv",
     "isclose",
     "pad_left",
     "pad",

--- a/src/haliax/ops.py
+++ b/src/haliax/ops.py
@@ -138,6 +138,29 @@ def isclose(a: NamedArray, b: NamedArray, rtol=1e-05, atol=1e-08, equal_nan=Fals
     return NamedArray(jnp.isclose(a.array, b.array, rtol=rtol, atol=atol, equal_nan=equal_nan), a.axes)
 
 
+def allclose(a: NamedArray, b: NamedArray, rtol=1e-05, atol=1e-08, equal_nan=False) -> bool:
+    """Returns True if two arrays are element-wise equal within a tolerance."""
+    a, b = broadcast_arrays(a, b)
+    return bool(jnp.allclose(a.array, b.array, rtol=rtol, atol=atol, equal_nan=equal_nan))
+
+
+def array_equal(a: NamedArray, b: NamedArray) -> bool:
+    """Returns True if two arrays have the same shape and elements."""
+    if set(a.axes) != set(b.axes):
+        return False
+    b = b.rearrange(a.axes)
+    return bool(jnp.array_equal(a.array, b.array))
+
+
+def array_equiv(a: NamedArray, b: NamedArray) -> bool:
+    """Returns True if two arrays are shape-consistent and equal."""
+    try:
+        a, b = broadcast_arrays(a, b)
+    except ValueError:
+        return False
+    return bool(jnp.array_equal(a.array, b.array))
+
+
 def pad_left(array: NamedArray, axis: Axis, new_axis: Axis, value=0) -> NamedArray:
     """Pad an array along named axes."""
     amount_to_pad_to = new_axis.size - axis.size

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -425,6 +425,32 @@ def test_bincount():
     assert jnp.allclose(out_w.array, expected_w)
 
 
+def test_allclose_array_equal_equiv():
+    A = Axis("A", 2)
+    B = Axis("B", 3)
+    x = hax.random.uniform(PRNGKey(0), (A, B))
+    y = x + 1e-6
+
+    assert hax.allclose(x, y)
+    assert not hax.allclose(x, x + 1.0)
+
+    x1 = hax.ones((A, B))
+    y_reordered = x1.rearrange((B, A))
+    assert hax.array_equal(x1, y_reordered)
+
+    scalar = hax.ones(())
+    assert hax.array_equiv(x1, scalar)
+    assert not hax.array_equal(x1, scalar)
+
+    y_vec = hax.ones((B,))
+    assert hax.array_equiv(x1, y_vec)
+    assert not hax.array_equal(x1, y_vec)
+
+    C = Axis("C", 4)
+    z = hax.ones((C,))
+    assert not hax.array_equiv(x1, z)
+
+
 def test_roll_scalar_named_shift():
     H = Axis("H", 4)
     W = Axis("W", 3)


### PR DESCRIPTION
## Summary
- add `allclose`, `array_equal`, and `array_equiv` for comparing NamedArrays
- document new comparison helpers and expose them in the API
- track completed API-parity items

## Testing
- `uv run pre-commit run --files .agents/projects/api_parity.md docs/api.md src/haliax/__init__.py src/haliax/ops.py tests/test_ops.py`
- `XLA_FLAGS=--xla_force_host_platform_device_count=8 PYTHONPATH=tests:src:. uv run pytest tests/test_ops.py::test_allclose_array_equal_equiv`


------
https://chatgpt.com/codex/tasks/task_e_68c3631baac0833199687716a9f7c705